### PR TITLE
style: add clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,111 @@
+---
+AccessModifierOffset: -4
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlines: Left
+AlignOperands: true
+AlignTrailingComments: true
+AllowAllParametersOfDeclarationOnNextLine: false
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: None
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: false
+BinPackArguments: true
+BinPackParameters: true
+BraceWrapping:
+  AfterClass: false
+  AfterControlStatement: false
+  AfterEnum: false
+  AfterFunction: true
+  AfterNamespace: true
+  AfterObjCDeclaration: false
+  AfterStruct: false
+  AfterUnion: false
+  AfterExternBlock: false
+  BeforeCatch: false
+  BeforeElse: false
+  IndentBraces: false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Custom
+BreakBeforeInheritanceComma: false
+BreakBeforeTernaryOperators: false
+BreakConstructorInitializersBeforeComma: false
+BreakConstructorInitializers: BeforeComma
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: false
+ColumnLimit: 120
+CommentPragmas: '^ IWYU pragma:'
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+ConstructorInitializerIndentWidth: 8
+ContinuationIndentWidth: 8
+Cpp11BracedListStyle: false
+DerivePointerAlignment: false
+DisableFormat: false
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: false
+
+ForEachMacros:
+ - 'SS_LIST_FOR_EACH'
+ - 'SS_LIST_FOR_EACH_SAVE'
+IncludeBlocks: Preserve
+IncludeCategories:
+  - Regex: '.*'
+    Priority: 1
+IncludeIsMainRegex: '(Test)?$'
+IndentCaseLabels: false
+IndentGotoLabels: false
+IndentPPDirectives: None
+IndentWidth: 8
+IndentWrappedFunctionNames: false
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: false
+MacroBlockBegin: ''
+MacroBlockEnd: ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBinPackProtocolList: Auto
+ObjCBlockIndentWidth: 8
+ObjCSpaceAfterProperty: true
+ObjCSpaceBeforeProtocolList: true
+
+# Taken from git's rules
+PenaltyBreakAssignment: 10
+PenaltyBreakBeforeFirstCallParameter: 30
+PenaltyBreakComment: 10
+PenaltyBreakFirstLessLess: 0
+PenaltyBreakString: 10
+PenaltyExcessCharacter: 100
+PenaltyReturnTypeOnItsOwnLine: 60
+
+PointerAlignment: Right
+ReflowComments: false
+SortIncludes: false
+SortUsingDeclarations: false
+SpaceAfterCStyleCast: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: ControlStatementsExceptForEachMacros
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles: false
+SpacesInContainerLiterals: false
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard: Cpp03
+TabWidth: 8
+UseTab: Always

--- a/src/softsim/storage.c
+++ b/src/softsim/storage.c
@@ -37,11 +37,9 @@ static int gen_abs_host_path(char *def_path, const struct ss_list *path, bool de
 
 	if (ss_list_empty(path)) {
 		if (def)
-			SS_LOGP(SSTORAGE, LERROR,
-				"%s: unable to generate path to load file definition\n", division);
+			SS_LOGP(SSTORAGE, LERROR, "%s: unable to generate path to load file definition\n", division);
 		else
-			SS_LOGP(SSTORAGE, LERROR,
-				"%s: unable to generate path to load file content\n", division);
+			SS_LOGP(SSTORAGE, LERROR, "%s: unable to generate path to load file content\n", division);
 		return -EINVAL;
 	}
 
@@ -49,26 +47,20 @@ static int gen_abs_host_path(char *def_path, const struct ss_list *path, bool de
 	host_fs_path_ptr = host_fs_path;
 
 	SS_LIST_FOR_EACH(path, path_cursor, struct ss_file, list) {
-		rc = snprintf(host_fs_path_ptr,
-			      sizeof(host_fs_path) - (host_fs_path_ptr -
-						      host_fs_path), path_cursor->fid > 0xffff ? "/%08x" : "/%04x",
-			      path_cursor->fid);
+		rc = snprintf(host_fs_path_ptr, sizeof(host_fs_path) - (host_fs_path_ptr - host_fs_path),
+			      path_cursor->fid > 0xffff ? "/%08x" : "/%04x", path_cursor->fid);
 		host_fs_path_ptr += rc;
 		path_last = path_cursor;
 	}
 
 	if (def) {
-		snprintf(abs_host_fs_path, sizeof(abs_host_fs_path), "%s%s.def",
-			 storage_path, host_fs_path);
-		SS_LOGP(SSTORAGE, LINFO,
-			"%s: requested file definition for %04x on host file system : %s\n",
-			division, path_last->fid, abs_host_fs_path);
+		snprintf(abs_host_fs_path, sizeof(abs_host_fs_path), "%s%s.def", storage_path, host_fs_path);
+		SS_LOGP(SSTORAGE, LINFO, "%s: requested file definition for %04x on host file system : %s\n", division,
+			path_last->fid, abs_host_fs_path);
 	} else {
-		snprintf(abs_host_fs_path, sizeof(abs_host_fs_path), "%s%s",
-			 storage_path, host_fs_path);
-		SS_LOGP(SSTORAGE, LINFO,
-			"%s: requested file content for %04x on host file system: %s\n",
-			division, path_last->fid, abs_host_fs_path);
+		snprintf(abs_host_fs_path, sizeof(abs_host_fs_path), "%s%s", storage_path, host_fs_path);
+		SS_LOGP(SSTORAGE, LINFO, "%s: requested file content for %04x on host file system: %s\n", division,
+			path_last->fid, abs_host_fs_path);
 	}
 
 	strncpy(def_path, abs_host_fs_path, PATH_MAX);
@@ -84,16 +76,14 @@ static int read_file_def(char *host_path, struct ss_file *file)
 
 	fd = fopen(host_path, "r");
 	if (!fd) {
-		SS_LOGP(SSTORAGE, LERROR,
-			"unable to open definition file: %s\n", host_path);
+		SS_LOGP(SSTORAGE, LERROR, "unable to open definition file: %s\n", host_path);
 		return -EINVAL;
 	}
 
 	rc = fgets(line_buf, sizeof(line_buf), fd);
 	fclose(fd);
 	if (!rc) {
-		SS_LOGP(SSTORAGE, LERROR,
-			"unable to read definition file: %s\n", host_path);
+		SS_LOGP(SSTORAGE, LERROR, "unable to read definition file: %s\n", host_path);
 		return -EINVAL;
 	}
 
@@ -131,8 +121,7 @@ int ss_storage_get_file_def(struct ss_list *path)
  *  \param[in] read_offset offset to start reading the file at.
  *  \param[in] read_len length of data to read.
  *  \returns buffer with content data on success, NULL on failure. */
-struct ss_buf *ss_storage_read_file(const struct ss_list *path,
-				    size_t read_offset, size_t read_len)
+struct ss_buf *ss_storage_read_file(const struct ss_list *path, size_t read_offset, size_t read_len)
 {
 	/*! Note: This function will allocate memory in fileto store the file
 	 *  contents. The caller must take care of freeing. */
@@ -158,16 +147,14 @@ struct ss_buf *ss_storage_read_file(const struct ss_list *path,
 
 	fd = fopen(host_path, "r");
 	if (!fd) {
-		SS_LOGP(SSTORAGE, LERROR, "unable to open content file: %s\n",
-			host_path);
+		SS_LOGP(SSTORAGE, LERROR, "unable to open content file: %s\n", host_path);
 		SS_FREE(line_buf);
 		return NULL;
 	}
 
 	rc = fseek(fd, read_offset * 2, SEEK_SET);
 	if (rc != 0) {
-		SS_LOGP(SSTORAGE, LERROR,
-			"unable to seek (read_offset=%lu) requested data in content file: %s\n",
+		SS_LOGP(SSTORAGE, LERROR, "unable to seek (read_offset=%lu) requested data in content file: %s\n",
 			read_offset, host_path);
 		SS_FREE(line_buf);
 		fclose(fd);
@@ -176,8 +163,7 @@ struct ss_buf *ss_storage_read_file(const struct ss_list *path,
 
 	fgets_rc = fread(line_buf, 2, read_len, fd);
 	if (fgets_rc != read_len) {
-		SS_LOGP(SSTORAGE, LERROR,
-			"unable to load content (read_offset=%lu, read_len=%lu) from file: %s\n",
+		SS_LOGP(SSTORAGE, LERROR, "unable to load content (read_offset=%lu, read_len=%lu) from file: %s\n",
 			read_offset, read_len, host_path);
 		SS_FREE(line_buf);
 		fclose(fd);
@@ -197,8 +183,7 @@ struct ss_buf *ss_storage_read_file(const struct ss_list *path,
  *  \param[in] write_offset offset to start writing the file at.
  *  \param[in] write_len length of data to be written.
  *  \returns 0 on success, -EINVAL on failure. */
-int ss_storage_write_file(const struct ss_list *path, const uint8_t *data,
-			  size_t write_offset, size_t write_len)
+int ss_storage_write_file(const struct ss_list *path, const uint8_t *data, size_t write_offset, size_t write_len)
 {
 	char host_path[PATH_MAX + 1];
 	int rc;
@@ -213,16 +198,14 @@ int ss_storage_write_file(const struct ss_list *path, const uint8_t *data,
 
 	fd = fopen(host_path, "r+");
 	if (!fd) {
-		SS_LOGP(SSTORAGE, LERROR, "unable to open content file: %s\n",
-			host_path);
+		SS_LOGP(SSTORAGE, LERROR, "unable to open content file: %s\n", host_path);
 		return -EINVAL;
 	}
 
 	rc = fseek(fd, write_offset * 2, SEEK_SET);
 	if (rc != 0) {
-		SS_LOGP(SSTORAGE, LERROR,
-			"unable to seek (write_offset=%lu) data to content file: %s\n",
-			write_offset, host_path);
+		SS_LOGP(SSTORAGE, LERROR, "unable to seek (write_offset=%lu) data to content file: %s\n", write_offset,
+			host_path);
 		fclose(fd);
 		return -EINVAL;
 	}
@@ -231,8 +214,7 @@ int ss_storage_write_file(const struct ss_list *path, const uint8_t *data,
 		snprintf(hex, sizeof(hex), "%02x", data[i]);
 		fwrite_rc = fwrite(hex, sizeof(hex) - 1, 1, fd);
 		if (fwrite_rc != 1) {
-			SS_LOGP(SSTORAGE, LERROR,
-				"unable to write (write_offset=%lu+%lu) data to content file: %s\n",
+			SS_LOGP(SSTORAGE, LERROR, "unable to write (write_offset=%lu+%lu) data to content file: %s\n",
 				write_offset, i, host_path);
 			fclose(fd);
 			return -EINVAL;
@@ -264,24 +246,20 @@ size_t ss_storage_get_file_len(const struct ss_list *path)
 
 	fd = fopen(host_path, "r");
 	if (!fd) {
-		SS_LOGP(SSTORAGE, LERROR, "unable to open content file: %s\n",
-			host_path);
+		SS_LOGP(SSTORAGE, LERROR, "unable to open content file: %s\n", host_path);
 		return 0;
 	}
 
 	rc = fseek(fd, 0, SEEK_END);
 	if (rc != 0) {
-		SS_LOGP(SSTORAGE, LERROR,
-			"unable to seek requested data in content file: %s\n",
-			host_path);
+		SS_LOGP(SSTORAGE, LERROR, "unable to seek requested data in content file: %s\n", host_path);
 		fclose(fd);
 		return 0;
 	}
 
 	file_size = ftell(fd);
 	if (file_size < 0) {
-		SS_LOGP(SSTORAGE, LERROR,
-			"unable to tell the size of the file: %s\n", host_path);
+		SS_LOGP(SSTORAGE, LERROR, "unable to tell the size of the file: %s\n", host_path);
 		fclose(fd);
 		return 0;
 	}
@@ -318,19 +296,14 @@ int ss_storage_delete(const struct ss_list *path)
 
 	rc = remove(host_path_def);
 	if (rc < 0) {
-		SS_LOGP(SSTORAGE, LERROR,
-			"unable to remove definition file: %s\n",
-			host_path_def);
+		SS_LOGP(SSTORAGE, LERROR, "unable to remove definition file: %s\n", host_path_def);
 		return -EINVAL;
 	}
 
-	snprintf(rm_command, sizeof(rm_command), "rm -rf %s",
-		 host_path_content);
+	snprintf(rm_command, sizeof(rm_command), "rm -rf %s", host_path_content);
 	rc = system(rm_command);
 	if (rc < 0) {
-		SS_LOGP(SSTORAGE, LERROR,
-			"unable to remove content file: %s\n",
-			host_path_content);
+		SS_LOGP(SSTORAGE, LERROR, "unable to remove content file: %s\n", host_path_content);
 		return -EINVAL;
 	}
 	return 0;
@@ -354,9 +327,7 @@ int ss_storage_update_def(const struct ss_list *path)
 		return -EINVAL;
 
 	if (!file->fci) {
-		SS_LOGP(SSTORAGE, LERROR,
-			"file (%04x) has no definition (FCP) set -- abort\n",
-			file->fid);
+		SS_LOGP(SSTORAGE, LERROR, "file (%04x) has no definition (FCP) set -- abort\n", file->fid);
 		return -EINVAL;
 	}
 
@@ -367,17 +338,14 @@ int ss_storage_update_def(const struct ss_list *path)
 
 	fd = fopen(host_path, "w");
 	if (!fd) {
-		SS_LOGP(SSTORAGE, LERROR,
-			"unable to create definition file: %s\n", host_path);
+		SS_LOGP(SSTORAGE, LERROR, "unable to create definition file: %s\n", host_path);
 		return -EINVAL;
 	}
 	for (i = 0; i < file->fci->len; i++) {
 		snprintf(hex, sizeof(hex), "%02x", file->fci->data[i]);
 		fwrite_rc = fwrite(hex, sizeof(hex) - 1, 1, fd);
 		if (fwrite_rc != 1) {
-			SS_LOGP(SSTORAGE, LERROR,
-				"unable to write file definition: %s\n",
-				host_path);
+			SS_LOGP(SSTORAGE, LERROR, "unable to write file definition: %s\n", host_path);
 			ss_storage_delete(path);
 			fclose(fd);
 			return -EINVAL;
@@ -414,16 +382,13 @@ int ss_storage_create_file(const struct ss_list *path, size_t file_len)
 	}
 	fd = fopen(host_path, "w");
 	if (!fd) {
-		SS_LOGP(SSTORAGE, LERROR, "unable to create content file: %s\n",
-			host_path);
+		SS_LOGP(SSTORAGE, LERROR, "unable to create content file: %s\n", host_path);
 		ss_storage_delete(path);
 		return -EINVAL;
 	}
 	for (i = 0; i < file_len * 2; i++) {
 		if (fputc('f', fd) != 'f') {
-			SS_LOGP(SSTORAGE, LERROR,
-				"unable to prefill content file: %s\n",
-				host_path);
+			SS_LOGP(SSTORAGE, LERROR, "unable to prefill content file: %s\n", host_path);
 			ss_storage_delete(path);
 			fclose(fd);
 			return -EINVAL;
@@ -461,8 +426,7 @@ int ss_storage_create_dir(const struct ss_list *path)
 		return 0;
 	rc = mkdir(host_path, 0700);
 	if (rc < 0) {
-		SS_LOGP(SSTORAGE, LERROR, "unable to create directory: %s\n",
-			host_path);
+		SS_LOGP(SSTORAGE, LERROR, "unable to create directory: %s\n", host_path);
 		ss_storage_delete(path);
 		return -EINVAL;
 	}

--- a/src/softsim/uicc/apdu.c
+++ b/src/softsim/uicc/apdu.c
@@ -48,12 +48,14 @@ void ss_apdu_toss(struct ss_apdu *apdu)
 	 * where an APDU is freed. */
 
 	if (apdu->lchan->last_apdu_keep) {
-		SS_LOGP(SLCHAN, LDEBUG, "freeing APDU %p (current), keeping APDU %p (last)\n", apdu, apdu->lchan->last_apdu);
+		SS_LOGP(SLCHAN, LDEBUG, "freeing APDU %p (current), keeping APDU %p (last)\n", apdu,
+			apdu->lchan->last_apdu);
 		SS_FREE(apdu);
 	} else {
 		if (apdu->lchan->last_apdu)
 			SS_FREE(apdu->lchan->last_apdu);
-		SS_LOGP(SLCHAN, LDEBUG, "freeing APDU %p (last), keeping APDU %p (current)\n", apdu->lchan->last_apdu, apdu);
+		SS_LOGP(SLCHAN, LDEBUG, "freeing APDU %p (last), keeping APDU %p (current)\n", apdu->lchan->last_apdu,
+			apdu);
 		apdu->lchan->last_apdu = apdu;
 	}
 }

--- a/src/softsim/uicc/btlv_dec.c
+++ b/src/softsim/uicc/btlv_dec.c
@@ -20,14 +20,15 @@
  * sets how many bytes the buffer pointer (enc) should be be advanced. The
  * parameter "bytes_ahead" sets the minimum valid bytes that the caller expects
  * to be available after the buffer pointer (enc) has been advanced. */
-#define CHECK_AND_ADVANCE(inc, bytes_ahead) \
-	if (len < bytes_used + inc + bytes_ahead) { \
-		SS_LOGP(SBTLV, LDEBUG, "exceeding buffer bounds: len=%zu, inc=%zu, bytes_ahead=%zu, cannot decode IE\n", \
-			len, (size_t) inc, (size_t) bytes_ahead); \
-		return NULL; \
-	} \
-	bytes_used+=inc; \
-	enc+=inc
+#define CHECK_AND_ADVANCE(inc, bytes_ahead)                                                                    \
+	if (len < bytes_used + inc + bytes_ahead) {                                                            \
+		SS_LOGP(SBTLV, LDEBUG,                                                                         \
+			"exceeding buffer bounds: len=%zu, inc=%zu, bytes_ahead=%zu, cannot decode IE\n", len, \
+			(size_t)inc, (size_t)bytes_ahead);                                                     \
+		return NULL;                                                                                   \
+	}                                                                                                      \
+	bytes_used += inc;                                                                                     \
+	enc += inc
 
 /* Return one decoded information element */
 static struct ber_tlv_ie *decode_ie(size_t *used_len, const uint8_t *enc, size_t len)
@@ -77,9 +78,7 @@ static struct ber_tlv_ie *decode_ie(size_t *used_len, const uint8_t *enc, size_t
 
 		/* Make sure the decoded length field length makes sense */
 		if (len_bytes == 0 || len_bytes > SS_BERTLV_MAX_LEN_BYTES) {
-			SS_LOGP(SBTLV, LDEBUG,
-				"invalid ber-tlv length field length (tag = 0x%02x)\n",
-				ie.tag);
+			SS_LOGP(SBTLV, LDEBUG, "invalid ber-tlv length field length (tag = 0x%02x)\n", ie.tag);
 			return NULL;
 		}
 
@@ -109,8 +108,7 @@ static struct ber_tlv_ie *decode_ie(size_t *used_len, const uint8_t *enc, size_t
 }
 
 /* Get a description for an IE with a specified tag that is assigned to a specified parent (id) */
-static const struct ber_tlv_desc *get_ie_descr(const struct ber_tlv_desc *descr,
-					       uint32_t tag_encoded,
+static const struct ber_tlv_desc *get_ie_descr(const struct ber_tlv_desc *descr, uint32_t tag_encoded,
 					       uint32_t id_parent)
 {
 	uint32_t i = 0;
@@ -119,8 +117,7 @@ static const struct ber_tlv_desc *get_ie_descr(const struct ber_tlv_desc *descr,
 		return NULL;
 
 	do {
-		if (descr[i].id_parent == id_parent
-		    && descr[i].tag_encoded == tag_encoded) {
+		if (descr[i].id_parent == id_parent && descr[i].tag_encoded == tag_encoded) {
 			return &descr[i];
 		}
 		i++;
@@ -137,9 +134,7 @@ static const struct ber_tlv_desc *get_ie_descr(const struct ber_tlv_desc *descr,
  *
  * Consecutive 0xFF bytes at the trailing end are tolerated.
  * */
-static struct ss_list *btlv_decode(const uint8_t *enc, size_t len,
-				   const struct ber_tlv_desc *descr,
-				   uint32_t id_parent)
+static struct ss_list *btlv_decode(const uint8_t *enc, size_t len, const struct ber_tlv_desc *descr, uint32_t id_parent)
 {
 	struct ber_tlv_ie *ie;
 	const struct ber_tlv_desc *ie_descr;
@@ -156,11 +151,9 @@ static struct ss_list *btlv_decode(const uint8_t *enc, size_t len,
 		ie = decode_ie(&used_len, enc, remaining_len);
 		if (ie) {
 			ss_list_put(list, &ie->list);
-			ie_descr = get_ie_descr(descr, ie->tag_encoded,
-						id_parent);
+			ie_descr = get_ie_descr(descr, ie->tag_encoded, id_parent);
 			if (ie_descr && ie_descr->title) {
-				ie->title =
-				    SS_ALLOC_N(strlen(ie_descr->title) + 1);
+				ie->title = SS_ALLOC_N(strlen(ie_descr->title) + 1);
 				strcpy(ie->title, ie_descr->title);
 			}
 		} else if (remaining_len > 0) {
@@ -179,13 +172,9 @@ static struct ss_list *btlv_decode(const uint8_t *enc, size_t len,
 		 * list of the IE. */
 		if (ie && ie->constr) {
 			if (ie_descr) {
-				ie->nested =
-				    btlv_decode(ie->value->data, ie->value->len,
-						descr, ie_descr->id);
+				ie->nested = btlv_decode(ie->value->data, ie->value->len, descr, ie_descr->id);
 			} else {
-				ie->nested =
-				    btlv_decode(ie->value->data, ie->value->len,
-						NULL, 0);
+				ie->nested = btlv_decode(ie->value->data, ie->value->len, NULL, 0);
 			}
 		}
 
@@ -202,8 +191,7 @@ static struct ss_list *btlv_decode(const uint8_t *enc, size_t len,
  *  \param[in] len length of the buffer that contains the BER-TLV encoded data.
  *  \param[in] descr decoded BER-TLV data that serves a description (titles).
  *  \returns pointer to allocated linked list with BER-TLV data (can be empty). */
-struct ss_list *ss_btlv_decode(const uint8_t *enc, size_t len,
-			       const struct ber_tlv_desc *descr)
+struct ss_list *ss_btlv_decode(const uint8_t *enc, size_t len, const struct ber_tlv_desc *descr)
 {
 	return btlv_decode(enc, len, descr, 0);
 }

--- a/src/softsim/uicc/btlv_utils.c
+++ b/src/softsim/uicc/btlv_utils.c
@@ -65,8 +65,7 @@ static int decode_tag(uint16_t *tag, enum ber_tlv_cls *cls, bool *constr, uint32
 	return 0;
 }
 
-static void dump_ie(const struct ber_tlv_ie *ie, uint8_t indent,
-		    enum log_subsys subsys, enum log_level level)
+static void dump_ie(const struct ber_tlv_ie *ie, uint8_t indent, enum log_subsys subsys, enum log_level level)
 {
 	char indent_str[256];
 	char *title_str, *value_str;
@@ -96,9 +95,8 @@ static void dump_ie(const struct ber_tlv_ie *ie, uint8_t indent,
 		delimiter = ' ';
 	}
 
-	SS_LOGP(subsys, level, "%s%s(tag=0x%02x(0x%02x), cls=%x, constr=%s, len=%zu)%c %s\n",
-		indent_str, title_str, ie->tag_encoded, ie->tag, ie->cls, ie->constr ? "true" : "false",
-		value_len, delimiter, value_str);
+	SS_LOGP(subsys, level, "%s%s(tag=0x%02x(0x%02x), cls=%x, constr=%s, len=%zu)%c %s\n", indent_str, title_str,
+		ie->tag_encoded, ie->tag, ie->cls, ie->constr ? "true" : "false", value_len, delimiter, value_str);
 }
 
 /*! Dump decoded BER-TLV data.
@@ -106,16 +104,14 @@ static void dump_ie(const struct ber_tlv_ie *ie, uint8_t indent,
  *  \param[in] indent indentation level of the generated output.
  *  \param[in] log_subsys log subsystem to generate the output for.
  *  \param[in] log_level log level to generate the output for. */
-void ss_btlv_dump(const struct ss_list *list, uint8_t indent,
-		  enum log_subsys log_subsys, enum log_level log_level)
+void ss_btlv_dump(const struct ss_list *list, uint8_t indent, enum log_subsys log_subsys, enum log_level log_level)
 {
 	struct ber_tlv_ie *ie;
 
 	SS_LIST_FOR_EACH(list, ie, struct ber_tlv_ie, list) {
 		dump_ie(ie, indent, log_subsys, log_level);
 		if (ie->constr && ie->nested) {
-			ss_btlv_dump(ie->nested, indent + 2, log_subsys,
-				     log_level);
+			ss_btlv_dump(ie->nested, indent + 2, log_subsys, log_level);
 		}
 	}
 }
@@ -184,8 +180,7 @@ void ss_btlv_free(struct ss_list *list)
  *  \param[in] len BER-TLV value length.
  *  \param[in] value pointer to BER-TLV value (data is copied).
  *  \returns pointer to allocated IE struct. */
-struct ber_tlv_ie *ss_btlv_new_ie(struct ss_list *parent, const char *title,
-				  uint32_t tag, size_t len,
+struct ber_tlv_ie *ss_btlv_new_ie(struct ss_list *parent, const char *title, uint32_t tag, size_t len,
 				  const uint8_t *value)
 {
 	int rc;
@@ -198,14 +193,12 @@ struct ber_tlv_ie *ss_btlv_new_ie(struct ss_list *parent, const char *title,
 	ie->tag_encoded = tag;
 	rc = decode_tag(&ie->tag, &ie->cls, &constr, tag);
 	if (rc < 0) {
-		SS_LOGP(SBTLV, LERROR,
-			"incorrect tag format (%02x), cannot create IE!\n", tag);
+		SS_LOGP(SBTLV, LERROR, "incorrect tag format (%02x), cannot create IE!\n", tag);
 		SS_FREE(ie);
 		return NULL;
 	}
 	if (constr != false) {
-		SS_LOGP(SBTLV, LERROR,
-			"tag does not describe a primitive ie (%02x), cannot create IE!\n", tag);
+		SS_LOGP(SBTLV, LERROR, "tag does not describe a primitive ie (%02x), cannot create IE!\n", tag);
 		SS_FREE(ie);
 		return NULL;
 	}
@@ -230,8 +223,7 @@ struct ber_tlv_ie *ss_btlv_new_ie(struct ss_list *parent, const char *title,
  *  \param[in] title human readable title that serves as a description.
  *  \param[in] tag BER-TLV tag (encoded format).
  *  \returns pointer to allocated IE struct. */
-struct ber_tlv_ie *ss_btlv_new_ie_constr(struct ss_list *parent,
-					 const char *title, uint32_t tag)
+struct ber_tlv_ie *ss_btlv_new_ie_constr(struct ss_list *parent, const char *title, uint32_t tag)
 {
 	int rc;
 	struct ber_tlv_ie *ie = SS_ALLOC(struct ber_tlv_ie);
@@ -243,14 +235,12 @@ struct ber_tlv_ie *ss_btlv_new_ie_constr(struct ss_list *parent,
 	ie->tag_encoded = tag;
 	rc = decode_tag(&ie->tag, &ie->cls, &constr, tag);
 	if (rc < 0) {
-		SS_LOGP(SBTLV, LERROR,
-			"incorrect tag format (%02x), cannot create IE!\n", tag);
+		SS_LOGP(SBTLV, LERROR, "incorrect tag format (%02x), cannot create IE!\n", tag);
 		SS_FREE(ie);
 		return NULL;
 	}
 	if (constr != true) {
-		SS_LOGP(SBTLV, LERROR,
-			"tag does not describe a constructed ie (%02x), cannot create IE!\n", tag);
+		SS_LOGP(SBTLV, LERROR, "tag does not describe a constructed ie (%02x), cannot create IE!\n", tag);
 		SS_FREE(ie);
 		return NULL;
 	}
@@ -284,8 +274,7 @@ struct ber_tlv_ie *ss_btlv_get_ie(const struct ss_list *list, uint32_t tag)
 	/* Make sure we search only for correctly formatted tags */
 	rc = decode_tag(NULL, NULL, NULL, tag);
 	if (rc < 0) {
-		SS_LOGP(SBTLV, LERROR,
-			"incorrect tag format (%02x), cannot search for IE!\n", tag);
+		SS_LOGP(SBTLV, LERROR, "incorrect tag format (%02x), cannot search for IE!\n", tag);
 		return NULL;
 	}
 
@@ -302,8 +291,7 @@ struct ber_tlv_ie *ss_btlv_get_ie(const struct ss_list *list, uint32_t tag)
  *  \param[in] tag BER-TLV tag to look for.
  *  \param[in] min_len minimum required length.
  *  \returns pointer to IE struct on success, NULL if IE is not found. */
-struct ber_tlv_ie *ss_btlv_get_ie_minlen(const struct ss_list *list,
-					 uint16_t tag, size_t min_len)
+struct ber_tlv_ie *ss_btlv_get_ie_minlen(const struct ss_list *list, uint16_t tag, size_t min_len)
 {
 	struct ber_tlv_ie *ie = ss_btlv_get_ie(list, tag);
 	if (!ie)

--- a/src/softsim/uicc/command.c
+++ b/src/softsim/uicc/command.c
@@ -129,7 +129,7 @@ const struct ss_command commands[] = {
 	{
 		.name = "CREATE FILE",
 		.cla = 0x00,
-		.cla_mask = 0xB0,	/* 0X or 4X */
+		.cla_mask = 0xB0, /* 0X or 4X */
 		.ins = TS_102_222_INS_CREATE_FILE,
 		.handler = ss_uicc_admin_cmd_create_file,
 		.case_ = SS_COMMAND_CASE_3,
@@ -137,7 +137,7 @@ const struct ss_command commands[] = {
 	{
 		.name = "DELETE FILE",
 		.cla = 0x00,
-		.cla_mask = 0xB0,	/* 0X or 4X */
+		.cla_mask = 0xB0, /* 0X or 4X */
 		.ins = TS_102_222_INS_DELETE_FILE,
 		.handler = ss_uicc_admin_cmd_delete_file,
 		.case_ = SS_COMMAND_CASE_3,
@@ -145,7 +145,7 @@ const struct ss_command commands[] = {
 	{
 		.name = "ACTIVATE",
 		.cla = 0x00,
-		.cla_mask = 0xB0,	/* 0X or 4X */
+		.cla_mask = 0xB0, /* 0X or 4X */
 		.ins = TS_102_221_INS_ACTIVATE_FILE,
 		.handler = ss_uicc_admin_cmd_activate_file,
 		.case_ = SS_COMMAND_CASE_3,
@@ -155,7 +155,7 @@ const struct ss_command commands[] = {
 	{
 		.name = "TERMINAL PROFILE",
 		.cla = 0x80,
-		.cla_mask = 0xB0,	/* 0X or 4X */
+		.cla_mask = 0xB0, /* 0X or 4X */
 		.ins = TS_102_221_INS_TERMINAL_PROFILE,
 		.handler = ss_uicc_cat_cmd_term_profile,
 		.case_ = SS_COMMAND_CASE_3,
@@ -163,7 +163,7 @@ const struct ss_command commands[] = {
 	{
 		.name = "ENVELOPE",
 		.cla = 0x80,
-		.cla_mask = 0xB0,	/* 0X or 4X */
+		.cla_mask = 0xB0, /* 0X or 4X */
 		.ins = TS_102_221_INS_ENVELOPE,
 		.handler = ss_uicc_cat_cmd_envelope,
 		.case_ = SS_COMMAND_CASE_3, /* It does have response data, but that's not being asked for by an LE */
@@ -171,7 +171,7 @@ const struct ss_command commands[] = {
 	{
 		.name = "FETCH",
 		.cla = 0x80,
-		.cla_mask = 0xB0,	/* 0X or 4X */
+		.cla_mask = 0xB0, /* 0X or 4X */
 		.ins = TS_102_221_INS_FETCH,
 		.handler = ss_uicc_cat_cmd_fetch,
 		.case_ = SS_COMMAND_CASE_2,
@@ -179,7 +179,7 @@ const struct ss_command commands[] = {
 	{
 		.name = "TERMINAL RESPONSE",
 		.cla = 0x80,
-		.cla_mask = 0xB0,	/* 0X or 4X */
+		.cla_mask = 0xB0, /* 0X or 4X */
 		.ins = TS_102_221_INS_TERMINAL_RESPONSE,
 		.handler = ss_uicc_cat_cmd_term_resp,
 		.case_ = SS_COMMAND_CASE_3,
@@ -189,7 +189,7 @@ const struct ss_command commands[] = {
 	{
 		.name = "MANAGE CHANNEL",
 		.cla = 0x00,
-		.cla_mask = 0xB0,	/* 0X or 4X */
+		.cla_mask = 0xB0, /* 0X or 4X */
 		.ins = TS_102_221_INS_MANAGE_CHANNEL,
 		.handler = ss_uicc_lchan_cmd_manage_channel,
 		.case_ = SS_COMMAND_CASE_2,
@@ -215,20 +215,18 @@ const struct ss_command *ss_command_match(struct ss_apdu *apdu)
 	unsigned int i;
 	bool cla_seen = false;
 
-	for(i = 0; i < SS_ARRAY_SIZE(commands); i++) {
+	for (i = 0; i < SS_ARRAY_SIZE(commands); i++) {
 		if ((apdu->hdr.cla & commands[i].cla_mask) == commands[i].cla)
 			cla_seen = true;
 
-		if ((apdu->hdr.cla & commands[i].cla_mask) == commands[i].cla
-		    && apdu->hdr.ins == commands[i].ins) {
+		if ((apdu->hdr.cla & commands[i].cla_mask) == commands[i].cla && apdu->hdr.ins == commands[i].ins) {
 			SS_LOGP(SCMD, LINFO, "command found (cla=%02X, cla_mask=%02X, ins=%02X, name=\"%s\")\n",
-			        commands[i].cla, commands[i].cla_mask, commands[i].ins, commands[i].name);
+				commands[i].cla, commands[i].cla_mask, commands[i].ins, commands[i].name);
 			return &commands[i];
 		}
 	}
 
-	SS_LOGP(SCMD, LERROR, "command not found (cla=%02X, ins=%02X)\n",
-		apdu->hdr.cla, apdu->hdr.ins);
+	SS_LOGP(SCMD, LERROR, "command not found (cla=%02X, ins=%02X)\n", apdu->hdr.cla, apdu->hdr.ins);
 
 	if (!cla_seen)
 		apdu->sw = SS_SW_ERR_CHECKING_CLA_INVALID;

--- a/src/softsim/uicc/df_name.c
+++ b/src/softsim/uicc/df_name.c
@@ -41,25 +41,20 @@ int ss_df_name_update(struct ss_list *path)
 	file = ss_get_file_from_path(path);
 
 	/* get FID */
-	fcp_fid_ie =
-	    ss_btlv_get_ie_minlen(file->fcp_decoded,
-				  TS_102_221_IEI_FCP_FILE_ID, 2);
+	fcp_fid_ie = ss_btlv_get_ie_minlen(file->fcp_decoded, TS_102_221_IEI_FCP_FILE_ID, 2);
 	if (!fcp_fid_ie)
 		return -EINVAL;
 
 	/* Extract DF Name (if present) */
-	fcp_df_name_ie = ss_btlv_get_ie_minlen(file->fcp_decoded,
-					       TS_102_221_IEI_FCP_DF_NAME, 1);
+	fcp_df_name_ie = ss_btlv_get_ie_minlen(file->fcp_decoded, TS_102_221_IEI_FCP_DF_NAME, 1);
 	if (!fcp_df_name_ie) {
 		/* Nothing to do, This file just has no DF_NAME assigned */
 		return 0;
 	}
 
 	if (fcp_df_name_ie->value->len > 16) {
-		SS_LOGP(SDFNAME, LERROR,
-			"cannot register too long DF_NAME %s, len=%lu > 16\n",
-			ss_hexdump(fcp_df_name_ie->value->data,
-				   fcp_df_name_ie->value->len),
+		SS_LOGP(SDFNAME, LERROR, "cannot register too long DF_NAME %s, len=%lu > 16\n",
+			ss_hexdump(fcp_df_name_ie->value->data, fcp_df_name_ie->value->len),
 			fcp_df_name_ie->value->len);
 		return -EINVAL;
 	}
@@ -87,15 +82,12 @@ int ss_df_name_update(struct ss_list *path)
 	/* Select lookup file. If it does not exist, create a new one. */
 	rc = ss_fs_select(&path_copy, DF_NAME_FID);
 	if (rc < 0) {
-		SS_LOGP(SDFNAME, LERROR,
-			"lookup file %s does not exist, creating a new one.\n",
+		SS_LOGP(SDFNAME, LERROR, "lookup file %s does not exist, creating a new one.\n",
 			ss_fs_utils_dump_path(&path_copy));
-		rc = ss_fs_utils_create_record_file(&path_copy, DF_NAME_FID,
-						    16 + 2, 16);
+		rc = ss_fs_utils_create_record_file(&path_copy, DF_NAME_FID, 16 + 2, 16);
 		rc += ss_fs_select(&path_copy, DF_NAME_FID);
 		if (rc < 0) {
-			SS_LOGP(SDFNAME, LERROR,
-				"failed to create lookup file %s\n",
+			SS_LOGP(SDFNAME, LERROR, "failed to create lookup file %s\n",
 				ss_fs_utils_dump_path(&path_copy));
 			rc = -EINVAL;
 			goto leave;
@@ -105,33 +97,25 @@ int ss_df_name_update(struct ss_list *path)
 	/* Find a free record */
 	free_record = ss_fs_utils_find_free_record(&path_copy);
 	if (!free_record) {
-		SS_LOGP(SDFNAME, LERROR,
-			"failed to register DF_NAME=%s in lookup file %s - no free record found\n",
-			ss_hexdump(fcp_df_name_ie->value->data,
-				   fcp_df_name_ie->value->len),
+		SS_LOGP(SDFNAME, LERROR, "failed to register DF_NAME=%s in lookup file %s - no free record found\n",
+			ss_hexdump(fcp_df_name_ie->value->data, fcp_df_name_ie->value->len),
 			ss_fs_utils_dump_path(&path_copy));
 		rc = -EINVAL;
 		goto leave;
 	}
 
-	rc = ss_fs_write_file_record(&path_copy, free_record, record,
-				     sizeof(record));
+	rc = ss_fs_write_file_record(&path_copy, free_record, record, sizeof(record));
 	if (rc < 0) {
-		SS_LOGP(SDFNAME, LERROR,
-			"failed to register DF_NAME=%s in lookup file %s - could not write record\n",
-			ss_hexdump(fcp_df_name_ie->value->data,
-				   fcp_df_name_ie->value->len),
+		SS_LOGP(SDFNAME, LERROR, "failed to register DF_NAME=%s in lookup file %s - could not write record\n",
+			ss_hexdump(fcp_df_name_ie->value->data, fcp_df_name_ie->value->len),
 			ss_fs_utils_dump_path(&path_copy));
 		rc = -EINVAL;
 		goto leave;
 	}
 
-	SS_LOGP(SDFNAME, LDEBUG,
-		"registered DF_NAME=%s for FID=%02x%02x in file %s on record number %lu\n",
-		ss_hexdump(fcp_df_name_ie->value->data,
-			   fcp_df_name_ie->value->len),
-		fcp_fid_ie->value->data[0], fcp_fid_ie->value->data[1],
-		ss_fs_utils_dump_path(&path_copy), free_record);
+	SS_LOGP(SDFNAME, LDEBUG, "registered DF_NAME=%s for FID=%02x%02x in file %s on record number %lu\n",
+		ss_hexdump(fcp_df_name_ie->value->data, fcp_df_name_ie->value->len), fcp_fid_ie->value->data[0],
+		fcp_fid_ie->value->data[1], ss_fs_utils_dump_path(&path_copy), free_record);
 	rc = 0;
 leave:
 	ss_path_reset(&path_copy);
@@ -143,8 +127,7 @@ leave:
  *  \param[in] df_name DF NAME to look for.
  *  \param[in] df_name_len length of the DF NAME.
  *  \returns 0 success, -EINVAL on failure */
-int ss_df_name_resolve(struct ss_list *path, const uint8_t *df_name,
-		       size_t df_name_len)
+int ss_df_name_resolve(struct ss_list *path, const uint8_t *df_name, size_t df_name_len)
 {
 	struct ss_list path_copy;
 	int rc;
@@ -171,10 +154,8 @@ int ss_df_name_resolve(struct ss_list *path, const uint8_t *df_name,
 		return -EINVAL;
 	rc = ss_fs_select(&path_copy, DF_NAME_FID);
 	if (rc < 0) {
-		SS_LOGP(SDFNAME, LERROR,
-			"cannot resolve DF_NAME=%s, unable to select lookup file in %s\n",
-			ss_hexdump(df_name, df_name_len),
-			ss_fs_utils_dump_path(&path_copy));
+		SS_LOGP(SDFNAME, LERROR, "cannot resolve DF_NAME=%s, unable to select lookup file in %s\n",
+			ss_hexdump(df_name, df_name_len), ss_fs_utils_dump_path(&path_copy));
 		rc = -EINVAL;
 		goto leave;
 	}
@@ -190,14 +171,11 @@ int ss_df_name_resolve(struct ss_list *path, const uint8_t *df_name,
 	memset(mask, 0x00, sizeof(mask));
 	memset(mask, 0xff, df_name_len);
 
-	record_number =
-	    ss_fs_utils_find_record(&path_copy, template, mask,
-				    sizeof(template));
+	record_number = ss_fs_utils_find_record(&path_copy, template, mask, sizeof(template));
 	if (!record_number) {
 		SS_LOGP(SDFNAME, LERROR,
 			"unable to resolve DF_NAME=%s to FID - lookup file %s has no matching record\n",
-			ss_hexdump(df_name, df_name_len),
-			ss_fs_utils_dump_path(&path_copy));
+			ss_hexdump(df_name, df_name_len), ss_fs_utils_dump_path(&path_copy));
 		rc = -EINVAL;
 		goto leave;
 	}
@@ -206,17 +184,14 @@ int ss_df_name_resolve(struct ss_list *path, const uint8_t *df_name,
 	if (!record) {
 		SS_LOGP(SDFNAME, LERROR,
 			"unable to resolve DF_NAME=%s to FID - lookup file %s is not readable at record number %lu\n",
-			ss_hexdump(df_name, df_name_len),
-			ss_fs_utils_dump_path(&path_copy), record_number);
+			ss_hexdump(df_name, df_name_len), ss_fs_utils_dump_path(&path_copy), record_number);
 		rc = -EINVAL;
 		goto leave;
 	}
 
 	fid = ss_uint32_from_array(record->data + 16, 2);
-	SS_LOGP(SDFNAME, LDEBUG,
-		"resolved DF_NAME=%s to FID=%04x using lookup file %s\n",
-		ss_hexdump(df_name, df_name_len), fid,
-		ss_fs_utils_dump_path(&path_copy));
+	SS_LOGP(SDFNAME, LDEBUG, "resolved DF_NAME=%s to FID=%04x using lookup file %s\n",
+		ss_hexdump(df_name, df_name_len), fid, ss_fs_utils_dump_path(&path_copy));
 	ss_buf_free(record);
 	rc = fid;
 

--- a/src/softsim/uicc/fcp.c
+++ b/src/softsim/uicc/fcp.c
@@ -16,149 +16,147 @@
 #include "btlv.h"
 #include "fcp.h"
 
-const struct ber_tlv_desc bertlv_tree_descr[] = {
-	{
-		.id = 1,
-		.id_parent = 0,
-		.title = "fcp_template",
-		.tag_encoded = 0x62,
-	},
-	{
-		.id = 2,
-		.id_parent = 1,
-		.title = "file_descriptor",
-		.tag_encoded = 0x82,
-	},
-	{
-		.id = 2,
-		.id_parent = 1,
-		.title = "DF_name",
-		.tag_encoded = 0x84,
-	},
-	{
-		.id = 3,
-		.id_parent = 1,
-		.title = "file_identifier",
-		.tag_encoded = 0x83,
-	},
-	{
-		.id = 4,
-		.id_parent = 1,
-		.title = "proprietary_info",
-		.tag_encoded = 0xA5,
-	},
-	{
-		.id = 4,
-		.id_parent = 4,
-		.title = "uicc_characteristics",
-		.tag_encoded = 0x80,
-	},
-	{
-		.id = 4,
-		.id_parent = 4,
-		.title = "application_power_consumption",
-		.tag_encoded = 0x81,
-	},
-	{
-		.id = 4,
-		.id_parent = 4,
-		.title = "minimum_app_clock_freq",
-		.tag_encoded = 0x82,
-	},
-	{
-		.id = 4,
-		.id_parent = 4,
-		.title = "available_memory",
-		.tag_encoded = 0x83,
-	},
-	{
-		.id = 4,
-		.id_parent = 4,
-		.title = "file_details",
-		.tag_encoded = 0x84,
-	},
-	{
-		.id = 4,
-		.id_parent = 4,
-		.title = "reserved_file_size",
-		.tag_encoded = 0x85,
-	},
-	{
-		.id = 4,
-		.id_parent = 4,
-		.title = "maximum_file_size",
-		.tag_encoded = 0x86,
-	},
-	{
-		.id = 4,
-		.id_parent = 4,
-		.title = "suported_system_commands",
-		.tag_encoded = 0x87,
-	},
-	{
-		.id = 4,
-		.id_parent = 4,
-		.title = "specific_uicc_env_cond",
-		.tag_encoded = 0x88,
-	},
-	{
-		.id = 4,
-		.id_parent = 4,
-		.title = "p2p_cat_secured_apdu",
-		.tag_encoded = 0x89,
-	},
-	{
-		.id = 4,
-		.id_parent = 1,
-		.title = "life_cycle_status_int",
-		.tag_encoded = 0x8A,
-	},
-	{
-		.id = 4,
-		.id_parent = 1,
-		.title = "security_attrib_ref_expanded",
-		.tag_encoded = 0xAB,
-	},
-	{
-		.id = 4,
-		.id_parent = 1,
-		.title = "security_attrib_compact",
-		.tag_encoded = 0x8C,
-	},
-	{
-		.id = 4,
-		.id_parent = 1,
-		.title = "security_attrib_expanded",
-		.tag_encoded = 0x8B,
-	},
-	{
-		.id = 4,
-		.id_parent = 1,
-		.title = "pin_status_template_do",
-		.tag_encoded = 0xC6,
-	},
-	{
-		.id = 4,
-		.id_parent = 1,
-		.title = "file_size",
-		.tag_encoded = 0x80,
-	},
-	{
-		.id = 4,
-		.id_parent = 1,
-		.title = "total_file_size",
-		.tag_encoded = 0x81,
-	},
-	{
-		.id = 4,
-		.id_parent = 1,
-		.title = "short_file_id",
-		.tag_encoded = 0x88,
-	},
-	{
-		.id = 0,
-	}
-};
+const struct ber_tlv_desc bertlv_tree_descr[] = { {
+							  .id = 1,
+							  .id_parent = 0,
+							  .title = "fcp_template",
+							  .tag_encoded = 0x62,
+						  },
+						  {
+							  .id = 2,
+							  .id_parent = 1,
+							  .title = "file_descriptor",
+							  .tag_encoded = 0x82,
+						  },
+						  {
+							  .id = 2,
+							  .id_parent = 1,
+							  .title = "DF_name",
+							  .tag_encoded = 0x84,
+						  },
+						  {
+							  .id = 3,
+							  .id_parent = 1,
+							  .title = "file_identifier",
+							  .tag_encoded = 0x83,
+						  },
+						  {
+							  .id = 4,
+							  .id_parent = 1,
+							  .title = "proprietary_info",
+							  .tag_encoded = 0xA5,
+						  },
+						  {
+							  .id = 4,
+							  .id_parent = 4,
+							  .title = "uicc_characteristics",
+							  .tag_encoded = 0x80,
+						  },
+						  {
+							  .id = 4,
+							  .id_parent = 4,
+							  .title = "application_power_consumption",
+							  .tag_encoded = 0x81,
+						  },
+						  {
+							  .id = 4,
+							  .id_parent = 4,
+							  .title = "minimum_app_clock_freq",
+							  .tag_encoded = 0x82,
+						  },
+						  {
+							  .id = 4,
+							  .id_parent = 4,
+							  .title = "available_memory",
+							  .tag_encoded = 0x83,
+						  },
+						  {
+							  .id = 4,
+							  .id_parent = 4,
+							  .title = "file_details",
+							  .tag_encoded = 0x84,
+						  },
+						  {
+							  .id = 4,
+							  .id_parent = 4,
+							  .title = "reserved_file_size",
+							  .tag_encoded = 0x85,
+						  },
+						  {
+							  .id = 4,
+							  .id_parent = 4,
+							  .title = "maximum_file_size",
+							  .tag_encoded = 0x86,
+						  },
+						  {
+							  .id = 4,
+							  .id_parent = 4,
+							  .title = "suported_system_commands",
+							  .tag_encoded = 0x87,
+						  },
+						  {
+							  .id = 4,
+							  .id_parent = 4,
+							  .title = "specific_uicc_env_cond",
+							  .tag_encoded = 0x88,
+						  },
+						  {
+							  .id = 4,
+							  .id_parent = 4,
+							  .title = "p2p_cat_secured_apdu",
+							  .tag_encoded = 0x89,
+						  },
+						  {
+							  .id = 4,
+							  .id_parent = 1,
+							  .title = "life_cycle_status_int",
+							  .tag_encoded = 0x8A,
+						  },
+						  {
+							  .id = 4,
+							  .id_parent = 1,
+							  .title = "security_attrib_ref_expanded",
+							  .tag_encoded = 0xAB,
+						  },
+						  {
+							  .id = 4,
+							  .id_parent = 1,
+							  .title = "security_attrib_compact",
+							  .tag_encoded = 0x8C,
+						  },
+						  {
+							  .id = 4,
+							  .id_parent = 1,
+							  .title = "security_attrib_expanded",
+							  .tag_encoded = 0x8B,
+						  },
+						  {
+							  .id = 4,
+							  .id_parent = 1,
+							  .title = "pin_status_template_do",
+							  .tag_encoded = 0xC6,
+						  },
+						  {
+							  .id = 4,
+							  .id_parent = 1,
+							  .title = "file_size",
+							  .tag_encoded = 0x80,
+						  },
+						  {
+							  .id = 4,
+							  .id_parent = 1,
+							  .title = "total_file_size",
+							  .tag_encoded = 0x81,
+						  },
+						  {
+							  .id = 4,
+							  .id_parent = 1,
+							  .title = "short_file_id",
+							  .tag_encoded = 0x88,
+						  },
+						  {
+							  .id = 0,
+						  } };
 
 /*! Get a btlv description with the most important FCP information elements.
  *  \returns description for use with ss_btlv_decode(). */
@@ -181,8 +179,7 @@ struct ss_list *ss_fcp_decode(const struct ss_buf *fcp)
  *  \param[out] user provided memory to store parsed file descriptor.
  *  \param[in] encoded representation of the file descriptor.
  *  \returns 0 on success -EINVAL on failure. */
-int ss_fcp_dec_file_descr(struct ss_fcp_file_descr *fd,
-			  const struct ss_buf *fd_encoded)
+int ss_fcp_dec_file_descr(struct ss_fcp_file_descr *fd, const struct ss_buf *fd_encoded)
 {
 	uint8_t fd_byte;
 
@@ -193,7 +190,7 @@ int ss_fcp_dec_file_descr(struct ss_fcp_file_descr *fd,
 	 * though the data coding byte is always 0x21 and ignored by the
 	 * terminal */
 	if (fd_encoded->len < 2)
-	        return -EINVAL;
+		return -EINVAL;
 
 	/* See also: ETSI TS 102 221, Table 11.5 */
 	fd_byte = fd_encoded->data[0];
@@ -212,8 +209,7 @@ int ss_fcp_dec_file_descr(struct ss_fcp_file_descr *fd,
 	}
 
 	/* See also: ETSI TS 102 221, Section 11.1.1.4.3 */
-	if (fd->structure == SS_FCP_LINEAR_FIXED ||
-	    fd->structure == SS_FCP_CYCLIC) {
+	if (fd->structure == SS_FCP_LINEAR_FIXED || fd->structure == SS_FCP_CYCLIC) {
 		if (fd_encoded->len < 5)
 			return -EINVAL;
 		fd->record_len = fd_encoded->data[2] << 8;
@@ -231,8 +227,7 @@ struct ss_buf *ss_fcp_gen_file_descr(const struct ss_fcp_file_descr *fd)
 {
 	struct ss_buf *result;
 
-	if (fd->structure == SS_FCP_LINEAR_FIXED ||
-	    fd->structure == SS_FCP_CYCLIC) {
+	if (fd->structure == SS_FCP_LINEAR_FIXED || fd->structure == SS_FCP_CYCLIC) {
 		result = ss_buf_alloc(5);
 		memset(result->data, 0, 5);
 	} else {
@@ -251,8 +246,7 @@ struct ss_buf *ss_fcp_gen_file_descr(const struct ss_fcp_file_descr *fd)
 	result->data[1] = 0x21;
 
 	/* Record oriented file */
-	if (fd->structure == SS_FCP_LINEAR_FIXED ||
-	    fd->structure == SS_FCP_CYCLIC) {
+	if (fd->structure == SS_FCP_LINEAR_FIXED || fd->structure == SS_FCP_CYCLIC) {
 		result->data[2] = fd->record_len >> 8;
 		result->data[3] = fd->record_len & 0xff;
 		result->data[4] = fd->number_of_records;
@@ -266,8 +260,7 @@ struct ss_buf *ss_fcp_gen_file_descr(const struct ss_fcp_file_descr *fd)
  *  \param[in] fid file ID.
  *  \param[in] file_size size of the file, if not already specified in fd.
  *  \returns buffer with generated file fcp on success NULL on failure. */
-struct ss_buf *ss_fcp_gen(const struct ss_fcp_file_descr *fd, uint32_t fid,
-			  size_t file_size)
+struct ss_buf *ss_fcp_gen(const struct ss_fcp_file_descr *fd, uint32_t fid, size_t file_size)
 {
 	/* NOTE: This file generates a file control parameter template (FCP)
 	 * that fullfills minimal requirements. The function is intended to
@@ -293,8 +286,7 @@ struct ss_buf *ss_fcp_gen(const struct ss_fcp_file_descr *fd, uint32_t fid,
 	fd_encoded = ss_fcp_gen_file_descr(fd);
 	if (!fd_encoded)
 		return NULL;
-	ss_btlv_new_ie(fcp_template->nested, "file_descriptor", 0x82,
-		       fd_encoded->len, fd_encoded->data);
+	ss_btlv_new_ie(fcp_template->nested, "file_descriptor", 0x82, fd_encoded->len, fd_encoded->data);
 	ss_buf_free(fd_encoded);
 
 	/* FID */
@@ -302,18 +294,15 @@ struct ss_buf *ss_fcp_gen(const struct ss_fcp_file_descr *fd, uint32_t fid,
 	if (fid > 0xffff)
 		fid_len = 4;
 	ss_array_from_uint32(fid_array, fid_len, fid);
-	ss_btlv_new_ie(fcp_template->nested, "file_identifier", 0x83, fid_len,
-		       fid_array);
+	ss_btlv_new_ie(fcp_template->nested, "file_identifier", 0x83, fid_len, fid_array);
 
 	/* File size */
-	if (fd->structure == SS_FCP_LINEAR_FIXED ||
-	    fd->structure == SS_FCP_CYCLIC) {
+	if (fd->structure == SS_FCP_LINEAR_FIXED || fd->structure == SS_FCP_CYCLIC) {
 		file_size = fd->record_len * fd->number_of_records;
 	}
 	file_size_len = ss_optimal_len_for_uint32(file_size);
 	ss_array_from_uint32(file_size_array, file_size_len, file_size);
-	ss_btlv_new_ie(fcp_template->nested, "file_size", 0x80, file_size_len,
-		       file_size_array);
+	ss_btlv_new_ie(fcp_template->nested, "file_size", 0x80, file_size_len, file_size_array);
 
 	result = ss_btlv_encode_to_ss_buf(fcp);
 	ss_btlv_free(fcp);
@@ -370,8 +359,7 @@ struct ss_buf *ss_fcp_get_df_name(const struct ss_list *fcp_decoded_envelope)
 	 *  the caller must not take ownership of the buffer (free it) */
 
 	/* Extract DF Name (if present) */
-	fcp_df_name_ie = ss_btlv_get_ie_minlen(fcp_decoded_envelope,
-					       TS_102_221_IEI_FCP_DF_NAME, 1);
+	fcp_df_name_ie = ss_btlv_get_ie_minlen(fcp_decoded_envelope, TS_102_221_IEI_FCP_DF_NAME, 1);
 	if (!fcp_df_name_ie)
 		return NULL;
 
@@ -383,8 +371,7 @@ struct ss_buf *ss_fcp_get_df_name(const struct ss_list *fcp_decoded_envelope)
  *  \param[in] indent indentation level of the generated output.
  *  \param[in] log_subsys log subsystem to generate the output for.
  *  \param[in] log_level log level to generate the output for. */
-void ss_fcp_dump_file_descr(const struct ss_fcp_file_descr *fd, uint8_t indent,
-			    enum log_subsys log_subsys,
+void ss_fcp_dump_file_descr(const struct ss_fcp_file_descr *fd, uint8_t indent, enum log_subsys log_subsys,
 			    enum log_level log_level)
 {
 	char indent_str[256];
@@ -392,61 +379,46 @@ void ss_fcp_dump_file_descr(const struct ss_fcp_file_descr *fd, uint8_t indent,
 	memset(indent_str, ' ', indent);
 	indent_str[indent] = '\0';
 
-	SS_LOGP(log_subsys, log_level, "%sshareable = %s\n", indent_str,
-		fd->shareable ? "true" : "false");
+	SS_LOGP(log_subsys, log_level, "%sshareable = %s\n", indent_str, fd->shareable ? "true" : "false");
 
 	switch (fd->type) {
 	case SS_FCP_WORKING_EF:
-		SS_LOGP(log_subsys, log_level, "%stype = \"working EF\"\n",
-			indent_str);
+		SS_LOGP(log_subsys, log_level, "%stype = \"working EF\"\n", indent_str);
 		break;
 	case SS_FCP_INTERNAL_EF:
-		SS_LOGP(log_subsys, log_level, "%stype = \"internal EF\"\n",
-			indent_str);
+		SS_LOGP(log_subsys, log_level, "%stype = \"internal EF\"\n", indent_str);
 		break;
 	case SS_FCP_DF_OR_ADF:
-		SS_LOGP(log_subsys, log_level, "%stype = \"DF or ADF\"\n",
-			indent_str);
+		SS_LOGP(log_subsys, log_level, "%stype = \"DF or ADF\"\n", indent_str);
 		break;
 	default:
-		SS_LOGP(log_subsys, log_level, "%stype = %x\n", indent_str,
-			fd->type);
+		SS_LOGP(log_subsys, log_level, "%stype = %x\n", indent_str, fd->type);
 		break;
 	}
 
 	switch (fd->structure) {
 	case SS_FCP_UNKNOWN:
-		SS_LOGP(log_subsys, log_level, "%sstructure = \"unknown\"\n",
-			indent_str);
+		SS_LOGP(log_subsys, log_level, "%sstructure = \"unknown\"\n", indent_str);
 		break;
 	case SS_FCP_TRANSPARENT:
-		SS_LOGP(log_subsys, log_level,
-			"%sstructure = \"transparent\"\n", indent_str);
+		SS_LOGP(log_subsys, log_level, "%sstructure = \"transparent\"\n", indent_str);
 		break;
 	case SS_FCP_LINEAR_FIXED:
-		SS_LOGP(log_subsys, log_level,
-			"%sstructure = \"linear fixed\"\n", indent_str);
+		SS_LOGP(log_subsys, log_level, "%sstructure = \"linear fixed\"\n", indent_str);
 		break;
 	case SS_FCP_CYCLIC:
-		SS_LOGP(log_subsys, log_level, "%sstructure = \"cyclic\"\n",
-			indent_str);
+		SS_LOGP(log_subsys, log_level, "%sstructure = \"cyclic\"\n", indent_str);
 		break;
 	case SS_FCP_BTLV:
-		SS_LOGP(log_subsys, log_level, "%sstructure = \"BTLV\"\n",
-			indent_str);
+		SS_LOGP(log_subsys, log_level, "%sstructure = \"BTLV\"\n", indent_str);
 		break;
 	default:
-		SS_LOGP(log_subsys, log_level, "%sstructure = %x\n", indent_str,
-			fd->structure);
+		SS_LOGP(log_subsys, log_level, "%sstructure = %x\n", indent_str, fd->structure);
 		break;
 	}
 
-	if (fd->structure == SS_FCP_LINEAR_FIXED
-	    || fd->structure == SS_FCP_CYCLIC) {
-		SS_LOGP(log_subsys, log_level, "%srecord_len = %u\n",
-			indent_str, fd->record_len);
-		SS_LOGP(log_subsys, log_level, "%snumber_of_records = %u\n",
-			indent_str, fd->number_of_records);
+	if (fd->structure == SS_FCP_LINEAR_FIXED || fd->structure == SS_FCP_CYCLIC) {
+		SS_LOGP(log_subsys, log_level, "%srecord_len = %u\n", indent_str, fd->record_len);
+		SS_LOGP(log_subsys, log_level, "%snumber_of_records = %u\n", indent_str, fd->number_of_records);
 	}
 }
-

--- a/src/softsim/uicc/fs_chg.c
+++ b/src/softsim/uicc/fs_chg.c
@@ -25,10 +25,10 @@ struct ss_file_blacklist {
  * identifiers. We don't want the terminal to be notified about file changes
  * in those files even when there is a file change */
 const static struct ss_file_blacklist blacklist[] = {
-	{.path_len = 4,.path = "\x3F\x00\xA0\x01" },
-	{.path_len = 4,.path = "\x3F\x00\xA0\x02" },
-	{.path_len = 4,.path = "\x3F\x00\xA0\x03" },
-	{.path_len = 4,.path = "\x3F\x00\xA0\x04" },
+	{ .path_len = 4, .path = "\x3F\x00\xA0\x01" },
+	{ .path_len = 4, .path = "\x3F\x00\xA0\x02" },
+	{ .path_len = 4, .path = "\x3F\x00\xA0\x03" },
+	{ .path_len = 4, .path = "\x3F\x00\xA0\x04" },
 };
 
 /* Check if a path is blacklisted */
@@ -93,14 +93,13 @@ static int pack_path(uint8_t result[SS_FS_CHG_PATH_MAXLEN], const struct ss_list
  *  \param[in] indent indentation level of the generated output.
  *  \param[in] log_subsys log subsystem to generate the output for.
  *  \param[in] log_level log level to generate the output for. */
-void ss_fs_chg_dump(const uint8_t filelist[SS_FS_CHG_BUF_SIZE], uint8_t indent,
-		    enum log_subsys subsys, enum log_level level)
+void ss_fs_chg_dump(const uint8_t filelist[SS_FS_CHG_BUF_SIZE], uint8_t indent, enum log_subsys subsys,
+		    enum log_level level)
 {
 	unsigned int i;
 	const uint8_t *files = filelist;
 	uint16_t fid;
-	char path_prn[SS_FS_CHG_PATH_MAXLEN * 2 + SS_FS_CHG_PATH_MAXLEN / 2 +
-		      1];
+	char path_prn[SS_FS_CHG_PATH_MAXLEN * 2 + SS_FS_CHG_PATH_MAXLEN / 2 + 1];
 	char *path_prn_ptr;
 	char indent_str[256];
 
@@ -118,29 +117,24 @@ void ss_fs_chg_dump(const uint8_t filelist[SS_FS_CHG_BUF_SIZE], uint8_t indent,
 		fid |= *files;
 		files++;
 		if ((fid & 0xFF00) != 0x3F00) {
-			SS_LOGP(subsys, level,
-				"Filelist invalid, path does not begin with 0x3FXX (MF)\n");
+			SS_LOGP(subsys, level, "Filelist invalid, path does not begin with 0x3FXX (MF)\n");
 			return;
 		}
 
 		do {
-			snprintf(path_prn_ptr,
-				 sizeof(path_prn) - (path_prn_ptr - path_prn),
-				 "/%04x", fid);
+			snprintf(path_prn_ptr, sizeof(path_prn) - (path_prn_ptr - path_prn), "/%04x", fid);
 			path_prn_ptr += 5;
 
 			fid = *files << 8;
 			files++;
 			if (files - filelist > SS_FS_CHG_BUF_SIZE) {
-				SS_LOGP(subsys, level,
-					"Filelist invalid, end of path not detected!");
+				SS_LOGP(subsys, level, "Filelist invalid, end of path not detected!");
 				return;
 			}
 			fid |= *files;
 			files++;
 			if (files - filelist > SS_FS_CHG_BUF_SIZE) {
-				SS_LOGP(subsys, level,
-					"Filelist invalid, end of path not detected!");
+				SS_LOGP(subsys, level, "Filelist invalid, end of path not detected!");
 				return;
 			}
 
@@ -180,10 +174,9 @@ int ss_fs_chg_add(uint8_t filelist[SS_FS_CHG_BUF_SIZE], const struct ss_list *pa
 
 	/* Advance to the end of the list */
 	for (i = 0; i < filelist[0]; i++) {
-
 		/* Check whether the file is already known */
-		if (files - filelist < SS_FS_CHG_BUF_SIZE - path_packed_len
-		    && memcmp(path_packed, files, path_packed_len) == 0)
+		if (files - filelist < SS_FS_CHG_BUF_SIZE - path_packed_len &&
+		    memcmp(path_packed, files, path_packed_len) == 0)
 			add = false;
 
 		/* Make sure the path starts with MF */

--- a/src/softsim/uicc/fs_utils.c
+++ b/src/softsim/uicc/fs_utils.c
@@ -36,9 +36,7 @@ char *ss_fs_utils_dump_path(const struct ss_list *path)
 	result_ptr = result;
 
 	SS_LIST_FOR_EACH(path, path_cursor, struct ss_file, list) {
-		rc = snprintf(result_ptr,
-			      sizeof(result) - (result_ptr - result), "/%04x",
-			      path_cursor->fid);
+		rc = snprintf(result_ptr, sizeof(result) - (result_ptr - result), "/%04x", path_cursor->fid);
 		result_ptr += rc;
 	}
 
@@ -63,14 +61,12 @@ size_t ss_fs_utils_find_free_record(const struct ss_list *path)
 	for (i = 0; i < file->fcp_file_descr->number_of_records; i++) {
 		record = ss_fs_read_file_record(path, i + 1);
 		if (!record) {
-			SS_LOGP(SFS, LERROR,
-				"cannot read record %lu in internal file: %s\n",
-				i + 1, ss_fs_utils_dump_path(path));
+			SS_LOGP(SFS, LERROR, "cannot read record %lu in internal file: %s\n", i + 1,
+				ss_fs_utils_dump_path(path));
 			return 0;
 		}
 		if (record->len == 0) {
-			SS_LOGP(SFS, LERROR,
-				"file (%s) seems to contain zero length record (bad file descriptor?)\n",
+			SS_LOGP(SFS, LERROR, "file (%s) seems to contain zero length record (bad file descriptor?)\n",
 				ss_fs_utils_dump_path(path));
 			return 0;
 		}
@@ -97,9 +93,7 @@ size_t ss_fs_utils_find_free_record(const struct ss_list *path)
  *  \param[in] mask a mask to tell which bits in the template matter.
  *  \param[in] len length of template and mask (both must be equal in length).
  *  \returns 0 on failure, record number on success. */
-size_t ss_fs_utils_find_record(const struct ss_list *path,
-			       const uint8_t *template,
-			       const uint8_t *mask, size_t len)
+size_t ss_fs_utils_find_record(const struct ss_list *path, const uint8_t *template, const uint8_t *mask, size_t len)
 {
 	struct ss_file *file;
 	size_t i;
@@ -117,9 +111,8 @@ size_t ss_fs_utils_find_record(const struct ss_list *path,
 	for (i = 0; i < file->fcp_file_descr->number_of_records; i++) {
 		record = ss_fs_read_file_record(path, i + 1);
 		if (!record) {
-			SS_LOGP(SFS, LERROR,
-				"cannot read record %lu in internal file: %s\n",
-				i + 1, ss_fs_utils_dump_path(path));
+			SS_LOGP(SFS, LERROR, "cannot read record %lu in internal file: %s\n", i + 1,
+				ss_fs_utils_dump_path(path));
 			return 0;
 		}
 
@@ -144,8 +137,7 @@ size_t ss_fs_utils_find_record(const struct ss_list *path,
  *  \param[in] record_len length of the records in the file.
  *  \param[in] number_of_records number of records in the file.
  *  \returns 0 success, -EINVAL on failure */
-int ss_fs_utils_create_record_file(const struct ss_list *path, uint32_t fid,
-				   uint16_t record_len,
+int ss_fs_utils_create_record_file(const struct ss_list *path, uint32_t fid, uint16_t record_len,
 				   uint8_t number_of_records)
 {
 	struct ss_buf *fcp;
@@ -178,16 +170,14 @@ int ss_fs_utils_create_record_file(const struct ss_list *path, uint32_t fid,
 	}
 	rc = ss_fs_create(&path_copy, fcp->data, fcp->len);
 	if (rc < 0) {
-		SS_LOGP(SFS, LERROR,
-			"cannot create internal file %08x in directory: %s\n",
-			fid, ss_fs_utils_dump_path(path));
+		SS_LOGP(SFS, LERROR, "cannot create internal file %08x in directory: %s\n", fid,
+			ss_fs_utils_dump_path(path));
 		rc = -EINVAL;
 		goto leave;
 	}
 
-	SS_LOGP(SFS, LDEBUG,
-		"created new internal record oriented file %08x in directory: %s\n",
-		fid, ss_fs_utils_dump_path(path));
+	SS_LOGP(SFS, LDEBUG, "created new internal record oriented file %08x in directory: %s\n", fid,
+		ss_fs_utils_dump_path(path));
 	rc = 0;
 leave:
 	ss_buf_free(fcp);
@@ -222,7 +212,8 @@ int ss_fs_utils_path_clone(struct ss_list *path_copy, const struct ss_list *path
 			goto err;
 		}
 		memcpy(latest, path_cursor, sizeof(*path_cursor));
-		latest->fcp_file_descr = memcpy(cloned_details, latest->fcp_file_descr, sizeof(struct ss_fcp_file_descr));
+		latest->fcp_file_descr =
+			memcpy(cloned_details, latest->fcp_file_descr, sizeof(struct ss_fcp_file_descr));
 		latest->fci = NULL;
 		latest->fcp_decoded = NULL;
 		latest->aid = NULL;
@@ -271,8 +262,7 @@ int ss_fs_utils_path_select(struct ss_list *path_out, const struct ss_list *path
  *  \param[in] path_a first path to compare.
  *  \param[in] path_b second path to compare.
  *  \returns true when both path are equal, false otherwise. */
-bool ss_fs_utils_path_equals(const struct ss_list *path_a,
-			     const struct ss_list *path_b)
+bool ss_fs_utils_path_equals(const struct ss_list *path_a, const struct ss_list *path_b)
 {
 	struct ss_file *path_cursor_a;
 	struct ss_file *path_cursor_b;
@@ -283,9 +273,7 @@ bool ss_fs_utils_path_equals(const struct ss_list *path_a,
 			return false;
 		if (path_cursor_a->fid != path_cursor_b->fid)
 			return false;
-		path_cursor_b =
-		    SS_LIST_GET_NEXT(&path_cursor_b->list, struct ss_file,
-				     list);
+		path_cursor_b = SS_LIST_GET_NEXT(&path_cursor_b->list, struct ss_file, list);
 	}
 
 	/* Check that there are no remaining items in path_b, this is the case

--- a/src/softsim/uicc/log.c
+++ b/src/softsim/uicc/log.c
@@ -10,7 +10,7 @@
 #include <onomondo/softsim/utils.h>
 
 uint32_t ss_log_mask = 0xffffffff;
-
+// clang-format off
 /* TODO #64: add a mechanism to modify the log levels at runtime via getopt */
 static uint32_t subsys_lvl[_NUM_LOG_SUBSYS] = {
 	[SBTLV] = LDEBUG,
@@ -59,11 +59,11 @@ static const char *subsys_str[_NUM_LOG_SUBSYS] = {
 	[SSMS]		= "SMS",
 	[SREFRESH]	= "REFRESH",
 };
-
+// clang-format on
 static const char *level_str[_NUM_LOG_LEVEL] = {
-	[LERROR]	= "ERROR",
-	[LINFO]		= "INFO",
-	[LDEBUG]	= "DEBUG",
+	[LERROR] = "ERROR",
+	[LINFO] = "INFO",
+	[LDEBUG] = "DEBUG",
 };
 
 /*! print a log line (called by IPA_LOGP, do not call directly).

--- a/src/softsim/uicc/proactive.c
+++ b/src/softsim/uicc/proactive.c
@@ -18,113 +18,111 @@
 /* Number of poll cycles until a TERMINAL RESPONSE is concidered lost. */
 #define MAX_POLL_CYCLES 30
 
-const struct ber_tlv_desc bertlv_cat_descr[] = {
-	{
-	 .id = 1,
-	 .id_parent = 0,
-	 .title = "proprietary",
-	 .tag_encoded = TS_101_220_IEI_PROPRITARY,
-	  },
-	{
-	 .id = 2,
-	 .id_parent = 0,
-	 .title = "proactive-command",
-	 .tag_encoded = TS_101_220_IEI_PROACTIVE_CMD,
-	  },
-	{
-	 .id = 3,
-	 .id_parent = 0,
-	 .title = "SMS-PP-download",
-	 .tag_encoded = TS_101_220_IEI_SMS_PP_DWNLD,
-	  },
-	{
-	 .id = 4,
-	 .id_parent = 0,
-	 .title = "cell-broadcast-download",
-	 .tag_encoded = TS_101_220_IEI_CBC_DWNLD,
-	  },
-	{
-	 .id = 5,
-	 .id_parent = 0,
-	 .title = "menu-selection",
-	 .tag_encoded = TS_101_220_IEI_MENU_SELECTION,
-	  },
-	{
-	 .id = 6,
-	 .id_parent = 0,
-	 .title = "call-control",
-	 .tag_encoded = TS_101_220_IEI_CALL_CTRL,
-	  },
-	{
-	 .id = 7,
-	 .id_parent = 0,
-	 .title = "MO-short-message-control",
-	 .tag_encoded = TS_101_220_IEI_MO_SMS_CTRL,
-	  },
-	{
-	 .id = 8,
-	 .id_parent = 0,
-	 .title = "event-download",
-	 .tag_encoded = TS_101_220_IEI_EVENT_DWNLD,
-	  },
-	{
-	 .id = 9,
-	 .id_parent = 0,
-	 .title = "timer-expiration",
-	 .tag_encoded = TS_101_220_IEI_TIMER_EXPIR,
-	  },
-	{
-	 .id = 10,
-	 .id_parent = 0,
-	 .title = "intra-uicc",
-	 .tag_encoded = TS_101_220_IEI_INTRA_UICC,
-	  },
-	{
-	 .id = 11,
-	 .id_parent = 0,
-	 .title = "USSD-download",
-	 .tag_encoded = TS_101_220_IEI_USSD_DWNLD,
-	  },
-	{
-	 .id = 12,
-	 .id_parent = 0,
-	 .title = "MMS-transfer-status",
-	 .tag_encoded = TS_101_220_IEI_MMS_TRX_STAT,
-	  },
-	{
-	 .id = 13,
-	 .id_parent = 0,
-	 .title = "MMS-notification-download",
-	 .tag_encoded = TS_101_220_IEI_MMS_NOTIF_DWNLD,
-	  },
-	{
-	 .id = 14,
-	 .id_parent = 0,
-	 .title = "Terminal-application-tag",
-	 .tag_encoded = TS_101_220_IEI_TERM_APP,
-	  },
-	{
-	 .id = 15,
-	 .id_parent = 0,
-	 .title = "geo-location-reporting-tag",
-	 .tag_encoded = TS_101_220_IEI_GEO_LOC,
-	  },
-	{
-	 .id = 16,
-	 .id_parent = 0,
-	 .title = "envelope-container",
-	 .tag_encoded = TS_101_220_IEI_ENVELOPE_CONTNR,
-	  },
-	{
-	 .id = 17,
-	 .id_parent = 0,
-	 .title = "ProSe-report-tag",
-	 .tag_encoded = TS_101_220_IEI_PROSE_REPORT,
-	  },
-	{
-	 .id = 0,
-	}
-};
+const struct ber_tlv_desc bertlv_cat_descr[] = { {
+							 .id = 1,
+							 .id_parent = 0,
+							 .title = "proprietary",
+							 .tag_encoded = TS_101_220_IEI_PROPRITARY,
+						 },
+						 {
+							 .id = 2,
+							 .id_parent = 0,
+							 .title = "proactive-command",
+							 .tag_encoded = TS_101_220_IEI_PROACTIVE_CMD,
+						 },
+						 {
+							 .id = 3,
+							 .id_parent = 0,
+							 .title = "SMS-PP-download",
+							 .tag_encoded = TS_101_220_IEI_SMS_PP_DWNLD,
+						 },
+						 {
+							 .id = 4,
+							 .id_parent = 0,
+							 .title = "cell-broadcast-download",
+							 .tag_encoded = TS_101_220_IEI_CBC_DWNLD,
+						 },
+						 {
+							 .id = 5,
+							 .id_parent = 0,
+							 .title = "menu-selection",
+							 .tag_encoded = TS_101_220_IEI_MENU_SELECTION,
+						 },
+						 {
+							 .id = 6,
+							 .id_parent = 0,
+							 .title = "call-control",
+							 .tag_encoded = TS_101_220_IEI_CALL_CTRL,
+						 },
+						 {
+							 .id = 7,
+							 .id_parent = 0,
+							 .title = "MO-short-message-control",
+							 .tag_encoded = TS_101_220_IEI_MO_SMS_CTRL,
+						 },
+						 {
+							 .id = 8,
+							 .id_parent = 0,
+							 .title = "event-download",
+							 .tag_encoded = TS_101_220_IEI_EVENT_DWNLD,
+						 },
+						 {
+							 .id = 9,
+							 .id_parent = 0,
+							 .title = "timer-expiration",
+							 .tag_encoded = TS_101_220_IEI_TIMER_EXPIR,
+						 },
+						 {
+							 .id = 10,
+							 .id_parent = 0,
+							 .title = "intra-uicc",
+							 .tag_encoded = TS_101_220_IEI_INTRA_UICC,
+						 },
+						 {
+							 .id = 11,
+							 .id_parent = 0,
+							 .title = "USSD-download",
+							 .tag_encoded = TS_101_220_IEI_USSD_DWNLD,
+						 },
+						 {
+							 .id = 12,
+							 .id_parent = 0,
+							 .title = "MMS-transfer-status",
+							 .tag_encoded = TS_101_220_IEI_MMS_TRX_STAT,
+						 },
+						 {
+							 .id = 13,
+							 .id_parent = 0,
+							 .title = "MMS-notification-download",
+							 .tag_encoded = TS_101_220_IEI_MMS_NOTIF_DWNLD,
+						 },
+						 {
+							 .id = 14,
+							 .id_parent = 0,
+							 .title = "Terminal-application-tag",
+							 .tag_encoded = TS_101_220_IEI_TERM_APP,
+						 },
+						 {
+							 .id = 15,
+							 .id_parent = 0,
+							 .title = "geo-location-reporting-tag",
+							 .tag_encoded = TS_101_220_IEI_GEO_LOC,
+						 },
+						 {
+							 .id = 16,
+							 .id_parent = 0,
+							 .title = "envelope-container",
+							 .tag_encoded = TS_101_220_IEI_ENVELOPE_CONTNR,
+						 },
+						 {
+							 .id = 17,
+							 .id_parent = 0,
+							 .title = "ProSe-report-tag",
+							 .tag_encoded = TS_101_220_IEI_PROSE_REPORT,
+						 },
+						 {
+							 .id = 0,
+						 } };
 
 /*! Get a btlv description for card application toolkit templates.
  *  \returns description for use with ss_btlv_decode(). */
@@ -135,19 +133,18 @@ const struct ber_tlv_desc *ss_proactive_get_cat_descr(void)
 
 const struct ss_proactive_task proactive_tasks[] = {
 	{
-	 .name = "SM QUEUE",
-	 .handler = ss_uicc_sms_tx_poll,
+		.name = "SM QUEUE",
+		.handler = ss_uicc_sms_tx_poll,
 	},
 	{
-	 .name = "REFRESH",
-	 .handler = ss_uicc_refresh_poll,
+		.name = "REFRESH",
+		.handler = ss_uicc_refresh_poll,
 	},
 };
 
 /* A defeult callback function that is used in case the caller does not supply
  * a callback function to handle TERMINAL RESPONSE */
-static void default_term_response_cb(struct ss_context *ctx,
-				     uint8_t *resp_data, uint8_t resp_data_len)
+static void default_term_response_cb(struct ss_context *ctx, uint8_t *resp_data, uint8_t resp_data_len)
 {
 	struct ss_list *ctlv_data = NULL;
 
@@ -156,13 +153,11 @@ static void default_term_response_cb(struct ss_context *ctx,
 		return;
 	}
 
-	SS_LOGP(SPROACT, LDEBUG, "terminal responded: %s\n",
-		ss_hexdump(resp_data, resp_data_len));
+	SS_LOGP(SPROACT, LDEBUG, "terminal responded: %s\n", ss_hexdump(resp_data, resp_data_len));
 
 	ctlv_data = ss_ctlv_decode(resp_data, resp_data_len);
 	if (!ctlv_data) {
-		SS_LOGP(SPROACT, LERROR,
-			"Unable to decode response - non valid COMPRESNSION-TLV?\n");
+		SS_LOGP(SPROACT, LERROR, "Unable to decode response - non valid COMPRESNSION-TLV?\n");
 		goto leave;
 	}
 	ss_ctlv_dump(ctlv_data, 2, SPROACT, LDEBUG);
@@ -179,8 +174,7 @@ void ss_proactive_poll(struct ss_context *ctx)
 
 	/* Go through all proactive tasks and call their handler functions. */
 	for (i = 0; i < SS_ARRAY_SIZE(proactive_tasks); i++) {
-		SS_LOGP(SPROACT, LDEBUG, "polling proactive task %s\n",
-			proactive_tasks[i].name);
+		SS_LOGP(SPROACT, LDEBUG, "polling proactive task %s\n", proactive_tasks[i].name);
 		proactive_tasks[i].handler(ctx);
 	}
 
@@ -190,20 +184,16 @@ void ss_proactive_poll(struct ss_context *ctx)
 	 * be called with NULL data. The timeout counting starts immediately
 	 * after the data is FETCHed. */
 	if (ctx->proactive.term_resp_cb && ctx->proactive.data_len > 0) {
-		SS_LOGP(SPROACT, LDEBUG,
-			"waiting for the terminal FETCH %u bytes of data\n",
-			ctx->proactive.data_len);
+		SS_LOGP(SPROACT, LDEBUG, "waiting for the terminal FETCH %u bytes of data\n", ctx->proactive.data_len);
 	} else if (ctx->proactive.term_resp_cb) {
 		if (ctx->proactive.term_resp_poll_ctr >= MAX_POLL_CYCLES) {
-			SS_LOGP(SPROACT, LDEBUG,
-				"giving up waiting for TERMINAL RESPONSE after %u poll cycles\n",
+			SS_LOGP(SPROACT, LDEBUG, "giving up waiting for TERMINAL RESPONSE after %u poll cycles\n",
 				ctx->proactive.term_resp_poll_ctr);
 			term_resp_cb callback = ctx->proactive.term_resp_cb;
 			ss_proactive_reset(ctx);
 			callback(ctx, NULL, 0);
 		} else {
-			SS_LOGP(SPROACT, LDEBUG,
-				"waiting %u poll cycles for TERMINAL RESPONSE\n",
+			SS_LOGP(SPROACT, LDEBUG, "waiting %u poll cycles for TERMINAL RESPONSE\n",
 				ctx->proactive.term_resp_poll_ctr);
 			ctx->proactive.term_resp_poll_ctr++;
 		}
@@ -228,8 +218,7 @@ bool ss_proactive_rts(const struct ss_context *ctx)
  *  \param[in] data command data (COMPRENSION TLV).
  *  \param[in] len length of data.
  *  \returns 0 on success, -EINVAL on error. */
-int ss_proactive_put(struct ss_context *ctx, term_resp_cb term_resp_cb,
-		     const uint8_t *data, size_t len)
+int ss_proactive_put(struct ss_context *ctx, term_resp_cb term_resp_cb, const uint8_t *data, size_t len)
 {
 	struct ss_list *proact_cmd;
 	int rc = 0;
@@ -239,8 +228,7 @@ int ss_proactive_put(struct ss_context *ctx, term_resp_cb term_resp_cb,
 	assert(len > 0);
 
 	if (ctx->proactive.data_len) {
-		SS_LOGP(SPROACT, LERROR,
-			"unable to put data, previous data not fetched yet!\n");
+		SS_LOGP(SPROACT, LERROR, "unable to put data, previous data not fetched yet!\n");
 		return -EBUSY;
 	}
 
@@ -252,15 +240,11 @@ int ss_proactive_put(struct ss_context *ctx, term_resp_cb term_resp_cb,
 
 	proact_cmd = SS_ALLOC(struct ss_list);
 	ss_list_init(proact_cmd);
-	ss_btlv_new_ie(proact_cmd, "proactive-command",
-		       TS_101_220_IEI_PROACTIVE_CMD, len, data);
+	ss_btlv_new_ie(proact_cmd, "proactive-command", TS_101_220_IEI_PROACTIVE_CMD, len, data);
 
-	ctx->proactive.data_len =
-	    ss_btlv_encode(ctx->proactive.data, sizeof(ctx->proactive.data),
-			   proact_cmd);
+	ctx->proactive.data_len = ss_btlv_encode(ctx->proactive.data, sizeof(ctx->proactive.data), proact_cmd);
 	if (ctx->proactive.data_len == 0) {
-		SS_LOGP(SPROACT, LERROR,
-			"unable to put data, cannot encode BER-TLV enevelope!\n");
+		SS_LOGP(SPROACT, LERROR, "unable to put data, cannot encode BER-TLV enevelope!\n");
 		rc = -EINVAL;
 	}
 
@@ -288,8 +272,7 @@ void ss_proactive_reset(struct ss_context *ctx)
  *  \param[in] rep_data COMPREHENSION-TLV encoded response setring.
  *  \param[in] resp_data_len length of the COMPREHEINSION-TLV encoded response string.
  *  \returns return code or -EINVAL when no returncode can be extracted. */
-int ss_proactive_get_rc(const uint8_t *resp_data, uint8_t resp_data_len,
-			enum log_subsys log_subsys)
+int ss_proactive_get_rc(const uint8_t *resp_data, uint8_t resp_data_len, enum log_subsys log_subsys)
 {
 	struct ss_list *ctlv_data = NULL;
 	struct cmp_tlv_ie *cmd_result_ie;
@@ -297,35 +280,29 @@ int ss_proactive_get_rc(const uint8_t *resp_data, uint8_t resp_data_len,
 
 	/* No response at all */
 	if (!resp_data) {
-		SS_LOGP(log_subsys, LDEBUG,
-			"no terminal response received -- command unsuccessful!\n");
+		SS_LOGP(log_subsys, LDEBUG, "no terminal response received -- command unsuccessful!\n");
 		return -EINVAL;
 	}
 
-	SS_LOGP(log_subsys, LDEBUG, "terminal responded: %s\n",
-		ss_hexdump(resp_data, resp_data_len));
+	SS_LOGP(log_subsys, LDEBUG, "terminal responded: %s\n", ss_hexdump(resp_data, resp_data_len));
 
 	/* Decode TLV */
 	ctlv_data = ss_ctlv_decode(resp_data, resp_data_len);
 	if (!ctlv_data) {
-		SS_LOGP(log_subsys, LERROR,
-			"Unable to decode response -- command unsuccessful!\n");
+		SS_LOGP(log_subsys, LERROR, "Unable to decode response -- command unsuccessful!\n");
 		rc = -EINVAL;
 		goto leave;
 	}
 	ss_ctlv_dump(ctlv_data, 2, log_subsys, LDEBUG);
 
 	/* Check result IE (mandatory) */
-	cmd_result_ie =
-	    ss_ctlv_get_ie_minlen(ctlv_data, TS_101_220_IEI_RESULT, 1);
+	cmd_result_ie = ss_ctlv_get_ie_minlen(ctlv_data, TS_101_220_IEI_RESULT, 1);
 	if (!cmd_result_ie) {
 		/* The result IE does not have the */
-		SS_LOGP(log_subsys, LERROR,
-			"result lacks mandatory RESULT IE -- command unsuccessful!\n");
+		SS_LOGP(log_subsys, LERROR, "result lacks mandatory RESULT IE -- command unsuccessful!\n");
 		rc = -EINVAL;
 	} else {
-		SS_LOGP(log_subsys, LDEBUG, "command result: %02x\n",
-			cmd_result_ie->value->data[0]);
+		SS_LOGP(log_subsys, LDEBUG, "command result: %02x\n", cmd_result_ie->value->data[0]);
 		rc = cmd_result_ie->value->data[0];
 	}
 
@@ -339,31 +316,25 @@ leave:
  *  \param[in] byte_idx byte index as defined in ETSI TS 102 223, section 5.2.
  *  \param[in] bit_idx as defined in ETSI TS 102 223, section 5.2.
  *  \returns true when feature is supported, false otherwiese. */
-bool ss_proactive_term_prof_bit(const struct ss_context *ctx, size_t byte_idx,
-				uint8_t bit_idx)
+bool ss_proactive_term_prof_bit(const struct ss_context *ctx, size_t byte_idx, uint8_t bit_idx)
 {
 	uint8_t byte;
 
 	if (byte_idx == 0) {
-		SS_LOGP(SPROACT, LERROR,
-			"TERMINAL PROFILE byte indexes start countingt at 1!\n");
+		SS_LOGP(SPROACT, LERROR, "TERMINAL PROFILE byte indexes start countingt at 1!\n");
 		assert(false);
 	}
 	if (bit_idx == 0) {
-		SS_LOGP(SPROACT, LERROR,
-			"TERMINAL PROFILE bit indexes start countingt at 1!\n");
+		SS_LOGP(SPROACT, LERROR, "TERMINAL PROFILE bit indexes start countingt at 1!\n");
 		assert(false);
 	}
 	if (byte_idx > sizeof(ctx->proactive.term_profile)) {
-		SS_LOGP(SPROACT, LERROR,
-			"Tried to access TERMINAL PROFILE byte %zu, but end ist at byte %zu!\n",
+		SS_LOGP(SPROACT, LERROR, "Tried to access TERMINAL PROFILE byte %zu, but end ist at byte %zu!\n",
 			byte_idx, sizeof(ctx->proactive.term_profile));
 		assert(false);
 	}
 	if (bit_idx > 8) {
-		SS_LOGP(SPROACT, LERROR,
-			"Tried to access TERMINAL PROFILE byte at bit %u!\n",
-			bit_idx);
+		SS_LOGP(SPROACT, LERROR, "Tried to access TERMINAL PROFILE byte at bit %u!\n", bit_idx);
 		assert(false);
 	}
 

--- a/src/softsim/uicc/sfi.c
+++ b/src/softsim/uicc/sfi.c
@@ -48,16 +48,12 @@ int ss_sfi_update(const struct ss_list *path)
 	file = ss_get_file_from_path(path);
 
 	/* get FID */
-	fcp_fid_ie =
-	    ss_btlv_get_ie_minlen(file->fcp_decoded,
-				  TS_102_221_IEI_FCP_FILE_ID, 2);
+	fcp_fid_ie = ss_btlv_get_ie_minlen(file->fcp_decoded, TS_102_221_IEI_FCP_FILE_ID, 2);
 	if (!fcp_fid_ie)
 		return -EINVAL;
 
 	/* get SFI */
-	fcp_sfi_ie =
-	    ss_btlv_get_ie(file->fcp_decoded,
-			   TS_102_221_IEI_FCP_SHORT_FILE_ID);
+	fcp_sfi_ie = ss_btlv_get_ie(file->fcp_decoded, TS_102_221_IEI_FCP_SHORT_FILE_ID);
 	if (!fcp_sfi_ie) {
 		/* See also ETSI TS 102 221 11.1.1.4.8 */
 		sfi = fcp_fid_ie->value->data[1] & 0x1f;
@@ -77,24 +73,19 @@ int ss_sfi_update(const struct ss_list *path)
 		return -EINVAL;
 	rc = ss_fs_select(&path_copy, SFI_FID);
 	if (rc < 0) {
-		SS_LOGP(SSFI, LERROR,
-			"cannot register SFI=%02x, unable to select lookup file %s\n",
-			sfi, ss_fs_utils_dump_path(&path_copy));
+		SS_LOGP(SSFI, LERROR, "cannot register SFI=%02x, unable to select lookup file %s\n", sfi,
+			ss_fs_utils_dump_path(&path_copy));
 		rc = -EINVAL;
 		goto leave;
 	}
-	rc = ss_fs_write_file_record(&path_copy, sfi,
-				     fcp_fid_ie->value->data,
-				     fcp_fid_ie->value->len);
+	rc = ss_fs_write_file_record(&path_copy, sfi, fcp_fid_ie->value->data, fcp_fid_ie->value->len);
 	if (rc < 0) {
 		rc = -EINVAL;
 		goto leave;
 	}
 
-	SS_LOGP(SSFI, LDEBUG,
-		"registered SFI=%02x for FID=%s in lookup file %s\n", sfi,
-		ss_hexdump(fcp_fid_ie->value->data, fcp_fid_ie->value->len),
-		ss_fs_utils_dump_path(&path_copy));
+	SS_LOGP(SSFI, LDEBUG, "registered SFI=%02x for FID=%s in lookup file %s\n", sfi,
+		ss_hexdump(fcp_fid_ie->value->data, fcp_fid_ie->value->len), ss_fs_utils_dump_path(&path_copy));
 	rc = 0;
 leave:
 	ss_path_reset(&path_copy);
@@ -123,24 +114,21 @@ int ss_sfi_resolve(const struct ss_list *path, uint8_t sfi)
 		return -EINVAL;
 	rc = ss_fs_select(&path_copy, SFI_FID);
 	if (rc < 0) {
-		SS_LOGP(SSFI, LERROR,
-			"cannot resolve SFI=%02x, unable to select lookup file %s\n",
-			sfi, ss_fs_utils_dump_path(&path_copy));
+		SS_LOGP(SSFI, LERROR, "cannot resolve SFI=%02x, unable to select lookup file %s\n", sfi,
+			ss_fs_utils_dump_path(&path_copy));
 		rc = -EINVAL;
 		goto leave;
 	}
 	fid = ss_fs_read_file_record(&path_copy, sfi);
 	if (!fid) {
-		SS_LOGP(SSFI, LERROR,
-			"unable to resolve SFI=%02x to FID - lookup file %s is not readable\n",
-			sfi, ss_fs_utils_dump_path(&path_copy));
+		SS_LOGP(SSFI, LERROR, "unable to resolve SFI=%02x to FID - lookup file %s is not readable\n", sfi,
+			ss_fs_utils_dump_path(&path_copy));
 		rc = -EINVAL;
 		goto leave;
 	}
 
 	rc = ss_uint32_from_array(fid->data, fid->len);
-	SS_LOGP(SSFI, LDEBUG,
-		"resolved SFI=%02x to FID=%04x using lookup file %s\n", sfi, rc,
+	SS_LOGP(SSFI, LDEBUG, "resolved SFI=%02x to FID=%04x using lookup file %s\n", sfi, rc,
 		ss_fs_utils_dump_path(&path_copy));
 leave:
 	ss_path_reset(&path_copy);

--- a/src/softsim/uicc/sms.c
+++ b/src/softsim/uicc/sms.c
@@ -18,8 +18,7 @@
 #include "sms.h"
 
 /* see also: 3GPP TS 23.040, section 9.2.3.1 */
-static enum ss_sms_tp_mti decode_mti(const uint8_t *sms_tpdu,
-				     size_t sms_tpdu_len, bool ms_to_sc)
+static enum ss_sms_tp_mti decode_mti(const uint8_t *sms_tpdu, size_t sms_tpdu_len, bool ms_to_sc)
 {
 	uint8_t mti;
 
@@ -35,8 +34,7 @@ static enum ss_sms_tp_mti decode_mti(const uint8_t *sms_tpdu,
 	return mti;
 }
 
-static int decode_addr(struct ss_sms_addr *addr_dec,
-		       const uint8_t *addr, size_t addr_len)
+static int decode_addr(struct ss_sms_addr *addr_dec, const uint8_t *addr, size_t addr_len)
 {
 	uint8_t n_digits;
 	uint8_t n_bytes;
@@ -89,8 +87,7 @@ static int decode_addr(struct ss_sms_addr *addr_dec,
 	return n_bytes + 2;
 }
 
-static int encode_addr(uint8_t *addr, size_t addr_len,
-		       const struct ss_sms_addr *addr_dec)
+static int encode_addr(uint8_t *addr, size_t addr_len, const struct ss_sms_addr *addr_dec)
 {
 	uint8_t n_digits;
 	uint8_t n_bytes;
@@ -102,8 +99,7 @@ static int encode_addr(uint8_t *addr, size_t addr_len,
 		return -ENOMEM;
 
 	/* Encode number of digits */
-	n_digits =
-	    (uint8_t) ss_strnlen(addr_dec->digits, sizeof(addr_dec->digits));
+	n_digits = (uint8_t)ss_strnlen(addr_dec->digits, sizeof(addr_dec->digits));
 	addr[bytes_used] = n_digits;
 	bytes_used++;
 
@@ -126,8 +122,7 @@ static int encode_addr(uint8_t *addr, size_t addr_len,
 		addr[bytes_used + i] = addr_dec->digits[d] & 0x0F;
 		d++;
 		if (d < n_digits)
-			addr[bytes_used + i] |=
-			    ((addr_dec->digits[d] & 0x0F) << 4);
+			addr[bytes_used + i] |= ((addr_dec->digits[d] & 0x0F) << 4);
 		else
 			addr[bytes_used + i] |= 0xF0;
 		d++;
@@ -138,8 +133,7 @@ static int encode_addr(uint8_t *addr, size_t addr_len,
 }
 
 /* see also: 3GPP TS 23.040, section 9.2.2.1 */
-static int rx_sms_deliver(struct ss_sms_deliver *sm, const uint8_t *sms_tpdu,
-			  size_t sms_tpdu_len)
+static int rx_sms_deliver(struct ss_sms_deliver *sm, const uint8_t *sms_tpdu, size_t sms_tpdu_len)
 {
 	int addr_len;
 	size_t bytes_used = 0;
@@ -158,20 +152,16 @@ static int rx_sms_deliver(struct ss_sms_deliver *sm, const uint8_t *sms_tpdu,
 	bytes_used++;
 
 	/* TP-OA */
-	addr_len =
-	    decode_addr(&sm->tp_oa, sms_tpdu + bytes_used,
-			sms_tpdu_len - bytes_used);
+	addr_len = decode_addr(&sm->tp_oa, sms_tpdu + bytes_used, sms_tpdu_len - bytes_used);
 	if (addr_len < 0) {
-		SS_LOGP(SSMS, LERROR,
-			"invalid address (TP-OA) -- reception of SMS-DELIVER failed!\n");
+		SS_LOGP(SSMS, LERROR, "invalid address (TP-OA) -- reception of SMS-DELIVER failed!\n");
 		return -EINVAL;
 	}
 	bytes_used += addr_len;
 
 	/* TP-PID */
 	if (sms_tpdu_len < bytes_used + 1) {
-		SS_LOGP(SSMS, LERROR,
-			"unexpected end of message (TP-PID) -- reception of SMS-DELIVER failed!\n");
+		SS_LOGP(SSMS, LERROR, "unexpected end of message (TP-PID) -- reception of SMS-DELIVER failed!\n");
 		return -EINVAL;
 	}
 	sm->tp_pid = sms_tpdu[bytes_used];
@@ -179,8 +169,7 @@ static int rx_sms_deliver(struct ss_sms_deliver *sm, const uint8_t *sms_tpdu,
 
 	/* TP-DCS */
 	if (sms_tpdu_len < bytes_used + 1) {
-		SS_LOGP(SSMS, LERROR,
-			"unexpected end of message (TP-DCS) -- reception of SMS-DELIVER failed!\n");
+		SS_LOGP(SSMS, LERROR, "unexpected end of message (TP-DCS) -- reception of SMS-DELIVER failed!\n");
 		return -EINVAL;
 	}
 	sm->tp_dcs = sms_tpdu[bytes_used];
@@ -188,8 +177,7 @@ static int rx_sms_deliver(struct ss_sms_deliver *sm, const uint8_t *sms_tpdu,
 
 	/* TP-SCTS */
 	if (sms_tpdu_len < bytes_used + 7) {
-		SS_LOGP(SSMS, LERROR,
-			"unexpected end of message (TP-SCTS) -- reception of SMS-DELIVER failed!\n");
+		SS_LOGP(SSMS, LERROR, "unexpected end of message (TP-SCTS) -- reception of SMS-DELIVER failed!\n");
 		return -EINVAL;
 	}
 	memcpy(sm->tp_scts, sms_tpdu + bytes_used, sizeof(sm->tp_scts));
@@ -197,8 +185,7 @@ static int rx_sms_deliver(struct ss_sms_deliver *sm, const uint8_t *sms_tpdu,
 
 	/* TP-UDL */
 	if (sms_tpdu_len < bytes_used + 1) {
-		SS_LOGP(SSMS, LERROR,
-			"unexpected end of message (TP-UDL) -- reception of SMS-DELIVER failed!\n");
+		SS_LOGP(SSMS, LERROR, "unexpected end of message (TP-UDL) -- reception of SMS-DELIVER failed!\n");
 		return -EINVAL;
 	}
 	sm->tp_udl = sms_tpdu[bytes_used];
@@ -208,8 +195,7 @@ static int rx_sms_deliver(struct ss_sms_deliver *sm, const uint8_t *sms_tpdu,
 }
 
 /* see also: 3GPP TS 23.040, section 9.2.2.3 */
-static int rx_sms_status_report(struct ss_sms_status_report *sm,
-				const uint8_t *sms_tpdu, size_t sms_tpdu_len)
+static int rx_sms_status_report(struct ss_sms_status_report *sm, const uint8_t *sms_tpdu, size_t sms_tpdu_len)
 {
 	int addr_len;
 	size_t bytes_used = 0;
@@ -220,20 +206,16 @@ static int rx_sms_status_report(struct ss_sms_status_report *sm,
 
 	/* TP-MR */
 	if (sms_tpdu_len < bytes_used + 1) {
-		SS_LOGP(SSMS, LERROR,
-			"unexpected end of message (TP-MR) -- reception of SMS-STATUS-REPORT failed!\n");
+		SS_LOGP(SSMS, LERROR, "unexpected end of message (TP-MR) -- reception of SMS-STATUS-REPORT failed!\n");
 		return -EINVAL;
 	}
 	sm->tp_mr = sms_tpdu[bytes_used];
 	bytes_used++;
 
 	/* TP-RA */
-	addr_len =
-	    decode_addr(&sm->tp_ra, sms_tpdu + bytes_used,
-			sms_tpdu_len - bytes_used);
+	addr_len = decode_addr(&sm->tp_ra, sms_tpdu + bytes_used, sms_tpdu_len - bytes_used);
 	if (addr_len < 0) {
-		SS_LOGP(SSMS, LERROR,
-			"invalid address (TP-RA) -- reception of SMS-STATUS-REPORT failed!\n");
+		SS_LOGP(SSMS, LERROR, "invalid address (TP-RA) -- reception of SMS-STATUS-REPORT failed!\n");
 		return -EINVAL;
 	}
 	bytes_used += addr_len;
@@ -249,8 +231,7 @@ static int rx_sms_status_report(struct ss_sms_status_report *sm,
 
 	/* TP-DT */
 	if (sms_tpdu_len < bytes_used + 7) {
-		SS_LOGP(SSMS, LERROR,
-			"unexpected end of message (TP-DT) -- reception of SMS-STATUS-REPORT failed!\n");
+		SS_LOGP(SSMS, LERROR, "unexpected end of message (TP-DT) -- reception of SMS-STATUS-REPORT failed!\n");
 		return -EINVAL;
 	}
 	memcpy(sm->tp_dt, sms_tpdu + bytes_used, sizeof(sm->tp_scts));
@@ -258,8 +239,7 @@ static int rx_sms_status_report(struct ss_sms_status_report *sm,
 
 	/* TP-ST */
 	if (sms_tpdu_len < bytes_used + 1) {
-		SS_LOGP(SSMS, LERROR,
-			"unexpected end of message (TP-ST) -- reception of SMS-STATUS-REPORT failed!\n");
+		SS_LOGP(SSMS, LERROR, "unexpected end of message (TP-ST) -- reception of SMS-STATUS-REPORT failed!\n");
 		return -EINVAL;
 	}
 	sm->tp_st = sms_tpdu[bytes_used];
@@ -269,8 +249,7 @@ static int rx_sms_status_report(struct ss_sms_status_report *sm,
 }
 
 /* see also: 3GPP TS 23.040, section 9.2.2.2 */
-static int rx_sms_submit_report(struct ss_sms_submit_report *sm,
-				const uint8_t *sms_tpdu, size_t sms_tpdu_len)
+static int rx_sms_submit_report(struct ss_sms_submit_report *sm, const uint8_t *sms_tpdu, size_t sms_tpdu_len)
 {
 	size_t bytes_used = 0;
 
@@ -279,8 +258,7 @@ static int rx_sms_submit_report(struct ss_sms_submit_report *sm,
 
 	/* TP-ST */
 	if (sms_tpdu_len < bytes_used + 1) {
-		SS_LOGP(SSMS, LERROR,
-			"unexpected end of message (TP-ST) -- reception of SMS-SUBMIT-REPORT failed!\n");
+		SS_LOGP(SSMS, LERROR, "unexpected end of message (TP-ST) -- reception of SMS-SUBMIT-REPORT failed!\n");
 		return -EINVAL;
 	}
 	sm->tp_fcs = sms_tpdu[bytes_used];
@@ -294,8 +272,7 @@ static int rx_sms_submit_report(struct ss_sms_submit_report *sm,
  *  \param[in] sms_tpdu buffer with binary SMS message header to decode.
  *  \param[in] sms_tpdu_len maximum length of sms_tpdu buffer.
  *  \returns 0 on success, -EINVAL on error. */
-int ss_sms_hdr_decode(struct ss_sm_hdr *sm_hdr, const uint8_t *sms_tpdu,
-		      size_t sms_tpdu_len)
+int ss_sms_hdr_decode(struct ss_sm_hdr *sm_hdr, const uint8_t *sms_tpdu, size_t sms_tpdu_len)
 {
 	memset(sm_hdr, 0, sizeof(*sm_hdr));
 
@@ -303,18 +280,13 @@ int ss_sms_hdr_decode(struct ss_sm_hdr *sm_hdr, const uint8_t *sms_tpdu,
 
 	switch (sm_hdr->tp_mti) {
 	case SMS_MTI_DELIVER:
-		return rx_sms_deliver(&sm_hdr->u.sms_deliver, sms_tpdu,
-				      sms_tpdu_len);
+		return rx_sms_deliver(&sm_hdr->u.sms_deliver, sms_tpdu, sms_tpdu_len);
 	case SMS_MTI_STATUS_REPORT:
-		return rx_sms_status_report(&sm_hdr->u.sms_status_report,
-					    sms_tpdu, sms_tpdu_len);
+		return rx_sms_status_report(&sm_hdr->u.sms_status_report, sms_tpdu, sms_tpdu_len);
 	case SMS_MTI_SUBMIT_REPORT:
-		return rx_sms_submit_report(&sm_hdr->u.sms_submit_report,
-					    sms_tpdu, sms_tpdu_len);
+		return rx_sms_submit_report(&sm_hdr->u.sms_submit_report, sms_tpdu, sms_tpdu_len);
 	default:
-		SS_LOGP(SSMS, LERROR,
-			"unexpected or invalid message type (mti=%u) received\n",
-			sm_hdr->tp_mti & 0x03);
+		SS_LOGP(SSMS, LERROR, "unexpected or invalid message type (mti=%u) received\n", sm_hdr->tp_mti & 0x03);
 		return -EINVAL;
 	}
 
@@ -322,8 +294,7 @@ int ss_sms_hdr_decode(struct ss_sm_hdr *sm_hdr, const uint8_t *sms_tpdu,
 }
 
 /* see also: 3GPP TS 23.040, section 9.2.2.1a */
-static int tx_sms_deliver_report(uint8_t *sms_tpdu, size_t sms_tpdu_len,
-				 const struct ss_sms_deliver_report *sm)
+static int tx_sms_deliver_report(uint8_t *sms_tpdu, size_t sms_tpdu_len, const struct ss_sms_deliver_report *sm)
 {
 	size_t bytes_used = 0;
 
@@ -377,8 +348,7 @@ static int tx_sms_deliver_report(uint8_t *sms_tpdu, size_t sms_tpdu_len,
 }
 
 /* see also: 3GPP TS 23.040, section 9.2.2.1a */
-static int tx_sms_command(uint8_t *sms_tpdu, size_t sms_tpdu_len,
-			  const struct ss_sms_command *sm)
+static int tx_sms_command(uint8_t *sms_tpdu, size_t sms_tpdu_len, const struct ss_sms_command *sm)
 {
 	size_t bytes_used = 0;
 	int rc;
@@ -415,8 +385,7 @@ static int tx_sms_command(uint8_t *sms_tpdu, size_t sms_tpdu_len,
 	bytes_used++;
 
 	/* TP-DA */
-	rc = encode_addr(&sms_tpdu[bytes_used], sms_tpdu_len - bytes_used,
-			 &sm->tp_da);
+	rc = encode_addr(&sms_tpdu[bytes_used], sms_tpdu_len - bytes_used, &sm->tp_da);
 	if (rc < 0)
 		return -EINVAL;
 	bytes_used += rc;
@@ -431,8 +400,7 @@ static int tx_sms_command(uint8_t *sms_tpdu, size_t sms_tpdu_len,
 }
 
 /* see also: 3GPP TS 23.040, section 9.2.2.2 */
-static int tx_sms_submit(uint8_t *sms_tpdu, size_t sms_tpdu_len,
-			 const struct ss_sms_submit *sm)
+static int tx_sms_submit(uint8_t *sms_tpdu, size_t sms_tpdu_len, const struct ss_sms_submit *sm)
 {
 	size_t bytes_used = 0;
 	int rc;
@@ -456,8 +424,7 @@ static int tx_sms_submit(uint8_t *sms_tpdu, size_t sms_tpdu_len,
 	bytes_used++;
 
 	/* TP-DA */
-	rc = encode_addr(&sms_tpdu[bytes_used], sms_tpdu_len - bytes_used,
-			 &sm->tp_da);
+	rc = encode_addr(&sms_tpdu[bytes_used], sms_tpdu_len - bytes_used, &sm->tp_da);
 	if (rc < 0)
 		return -EINVAL;
 	bytes_used += rc;
@@ -496,8 +463,7 @@ static int tx_sms_submit(uint8_t *sms_tpdu, size_t sms_tpdu_len,
  *  \param[in] sms_tpdu_len maximum length of sms_tpdu buffer.
  *  \param[in] sm_hdr pointer to user struct that holds the header data to encode.
  *  \returns 0 on success, -EINVAL on error. */
-int ss_sms_hdr_encode(uint8_t *sms_tpdu, size_t sms_tpdu_len,
-		      const struct ss_sm_hdr *sm_hdr)
+int ss_sms_hdr_encode(uint8_t *sms_tpdu, size_t sms_tpdu_len, const struct ss_sm_hdr *sm_hdr)
 {
 	memset(sms_tpdu, 0, sms_tpdu_len);
 
@@ -508,17 +474,13 @@ int ss_sms_hdr_encode(uint8_t *sms_tpdu, size_t sms_tpdu_len,
 
 	switch (sm_hdr->tp_mti) {
 	case SMS_MTI_DELIVER_REPORT:
-		return tx_sms_deliver_report(sms_tpdu, sms_tpdu_len,
-					     &sm_hdr->u.sms_deliver_report);
+		return tx_sms_deliver_report(sms_tpdu, sms_tpdu_len, &sm_hdr->u.sms_deliver_report);
 	case SMS_MTI_COMMAND:
-		return tx_sms_command(sms_tpdu, sms_tpdu_len,
-				      &sm_hdr->u.sms_command);
+		return tx_sms_command(sms_tpdu, sms_tpdu_len, &sm_hdr->u.sms_command);
 	case SMS_MTI_SUBMIT:
-		return tx_sms_submit(sms_tpdu, sms_tpdu_len,
-				     &sm_hdr->u.sms_submit);
+		return tx_sms_submit(sms_tpdu, sms_tpdu_len, &sm_hdr->u.sms_submit);
 	default:
-		SS_LOGP(SSMS, LERROR,
-			"cannot encode message with unexpected message type (mti=%u)\n",
+		SS_LOGP(SSMS, LERROR, "cannot encode message with unexpected message type (mti=%u)\n",
 			sm_hdr->tp_mti & 0x03);
 		return -EINVAL;
 	}

--- a/src/softsim/uicc/softsim.c
+++ b/src/softsim/uicc/softsim.c
@@ -92,8 +92,7 @@ void ss_free_ctx(struct ss_context *ctx)
  *  \param[inout] ctx softsim context. */
 void ss_reset(struct ss_context *ctx)
 {
-	SS_LOGP(SLCHAN, LDEBUG,
-		"------------------------------- reset -------------------------------\n");
+	SS_LOGP(SLCHAN, LDEBUG, "------------------------------- reset -------------------------------\n");
 
 	/* Reset lchan(s) */
 	ss_uicc_lchan_reset(ctx);
@@ -128,10 +127,8 @@ size_t ss_atr(struct ss_context *ctx, uint8_t *atr_buf, size_t atr_buf_len)
 	uint8_t tck = 0;
 	size_t i;
 
-	uint8_t atr[] =
-	    { 0x3B, 0x9F, 0x01, 0x80, 0x1F, 0x87, 0x80, 0x31, 0xE0, 0x73, 0xFE,
-		0x21, 0x00, 0x67, 0x4A, 0x4C, 0x75, 0x30, 0x34, 0x05, 0x4B
-	};
+	uint8_t atr[] = { 0x3B, 0x9F, 0x01, 0x80, 0x1F, 0x87, 0x80, 0x31, 0xE0, 0x73, 0xFE,
+			  0x21, 0x00, 0x67, 0x4A, 0x4C, 0x75, 0x30, 0x34, 0x05, 0x4B };
 
 	for (i = 1; i < sizeof(atr); i++) {
 		tck ^= atr[i];
@@ -155,12 +152,10 @@ static int apdu_transact(struct ss_context *ctx, struct ss_apdu *apdu)
 
 	int processed_length = -1;
 
-	SS_LOGP(SLCHAN, LDEBUG,
-		"------------------------- transaction begins ------------------------\n");
+	SS_LOGP(SLCHAN, LDEBUG, "------------------------- transaction begins ------------------------\n");
 
-	SS_LOGP(SLCHAN, LDEBUG, "Rx C-APDU %02X-%02X %02X-%02X %02X\n",
-		apdu->hdr.cla, apdu->hdr.ins, apdu->hdr.p1, apdu->hdr.p2,
-		apdu->hdr.p3);
+	SS_LOGP(SLCHAN, LDEBUG, "Rx C-APDU %02X-%02X %02X-%02X %02X\n", apdu->hdr.cla, apdu->hdr.ins, apdu->hdr.p1,
+		apdu->hdr.p2, apdu->hdr.p3);
 
 	/* TS 102 221 Table 10.3 */
 	if (apdu->hdr.cla & 0x0C) {
@@ -184,8 +179,7 @@ static int apdu_transact(struct ss_context *ctx, struct ss_apdu *apdu)
 	 * error cases. */
 	ss_fs_utils_path_clone(&backup_path, &apdu->lchan->fs_path);
 
-	if (((apdu->hdr.cla & 0x70) == 0x00)
-	    && apdu->hdr.ins == TS_102_221_INS_GET_RESPONSE) {
+	if (((apdu->hdr.cla & 0x70) == 0x00) && apdu->hdr.ins == TS_102_221_INS_GET_RESPONSE) {
 		/* The GET RESPONSE command is of command case 2 (see also command.h) */
 		processed_length = 5;
 
@@ -197,23 +191,20 @@ static int apdu_transact(struct ss_context *ctx, struct ss_apdu *apdu)
 		if (apdu->hdr.p1 != 0 || apdu->hdr.p2 != 0) {
 			apdu->sw = SS_SW_ERR_CHECKING_WRONG_P1_P2;
 			apdu->le = 0;
-			SS_LOGP(SLCHAN, LERROR,
-				"P1 and P2 must be 0x00 -- abort.\n");
+			SS_LOGP(SLCHAN, LERROR, "P1 and P2 must be 0x00 -- abort.\n");
 			goto out;
 		}
 		if (!last_apdu) {
 			apdu->sw = SS_SW_ERR_CHECKING_NO_PRECISE_DIAG;
 			apdu->le = 0;
-			SS_LOGP(SLCHAN, LERROR,
-				"no previous APDU in storage, cannot return any response -- abort.\n");
+			SS_LOGP(SLCHAN, LERROR, "no previous APDU in storage, cannot return any response -- abort.\n");
 			goto out;
 		}
 		if (last_apdu->rsp_len == 0) {
 			apdu->rsp_len = 0;
 			apdu->sw = SS_SW_ERR_CHECKING_WRONG_LENGTH;
 			apdu->le = 0;
-			SS_LOGP(SLCHAN, LERROR,
-				"last command did not return any response -- abort.\n");
+			SS_LOGP(SLCHAN, LERROR, "last command did not return any response -- abort.\n");
 			goto out;
 		}
 
@@ -226,8 +217,7 @@ static int apdu_transact(struct ss_context *ctx, struct ss_apdu *apdu)
 			 * up the data in a second try. */
 			apdu->lchan->last_apdu_keep = true;
 			apdu->le = 0;
-			SS_LOGP(SLCHAN, LERROR,
-				"incorrect response length requested (%u), expecting %lu\n",
+			SS_LOGP(SLCHAN, LERROR, "incorrect response length requested (%u), expecting %lu\n",
 				apdu->hdr.p3, last_apdu->rsp_len);
 		} else {
 			memcpy(apdu->rsp, last_apdu->rsp, last_apdu->rsp_len);
@@ -238,13 +228,11 @@ static int apdu_transact(struct ss_context *ctx, struct ss_apdu *apdu)
 		/* Match APDU and execute command handler */
 		cmd = ss_command_match(apdu);
 		if (cmd) {
-
 			/* Verify properties */
 			switch (cmd->case_) {
 			case SS_COMMAND_CASE_UNDEF:
 				SS_LOGP(SLCHAN, LERROR,
-					"Command %s found, but not executing for lack of case definition\n",
-					cmd->name);
+					"Command %s found, but not executing for lack of case definition\n", cmd->name);
 				apdu->sw = SS_SW_ERR_CHECKING_INS_INVALID;
 				goto out;
 			case SS_COMMAND_CASE_1:
@@ -261,25 +249,20 @@ static int apdu_transact(struct ss_context *ctx, struct ss_apdu *apdu)
 					/* Abort here, the handler would treat
 					 * p3 as Lc and then peek into
 					 * uninitialized memory */
-					SS_LOGP(SLCHAN, LERROR,
-						"Insufficient data for Case 3/4 command\n");
-					apdu->sw =
-					    SS_SW_ERR_CHECKING_WRONG_LENGTH;
+					SS_LOGP(SLCHAN, LERROR, "Insufficient data for Case 3/4 command\n");
+					apdu->sw = SS_SW_ERR_CHECKING_WRONG_LENGTH;
 					goto out;
 				}
 				processed_length = 4 + 1 + apdu->hdr.p3;
 				break;
 			}
 
-			SS_LOGP(SLCHAN, LDEBUG,
-				"Command %s is APDU CASE %u => lc=%u, le=%u\n",
-				cmd->name, cmd->case_, apdu->lc, apdu->le);
+			SS_LOGP(SLCHAN, LDEBUG, "Command %s is APDU CASE %u => lc=%u, le=%u\n", cmd->name, cmd->case_,
+				apdu->lc, apdu->le);
 
 			if (apdu->lc)
-				SS_LOGP(SLCHAN, LDEBUG,
-					"Rx C-APDU body %s (%u bytes)\n",
-					ss_hexdump(apdu->cmd, apdu->lc),
-					apdu->lc);
+				SS_LOGP(SLCHAN, LDEBUG, "Rx C-APDU body %s (%u bytes)\n",
+					ss_hexdump(apdu->cmd, apdu->lc), apdu->lc);
 
 			apdu->sw = 0;
 			rc = cmd->handler(apdu);
@@ -289,8 +272,7 @@ static int apdu_transact(struct ss_context *ctx, struct ss_apdu *apdu)
 				 * use the rc as SW or set a generic one here,
 				 * depending on the handler return code */
 				if (rc < 0)
-					apdu->sw =
-					    SS_SW_ERR_CHECKING_NO_PRECISE_DIAG;
+					apdu->sw = SS_SW_ERR_CHECKING_NO_PRECISE_DIAG;
 				else if (rc == 0)
 					apdu->sw = SS_SW_NORMAL_ENDING;
 				else
@@ -312,28 +294,23 @@ out:
 		}
 	} else {
 		if (apdu->le == 0) {
-			SS_LOGP(SLCHAN, LDEBUG,
-				"Returning rsp_len = %lu bytes after le = 0\n",
-				apdu->rsp_len);
+			SS_LOGP(SLCHAN, LDEBUG, "Returning rsp_len = %lu bytes after le = 0\n", apdu->rsp_len);
 		} else if (apdu->le != apdu->rsp_len) {
 			SS_LOGP(SLCHAN, LERROR,
 				"invalid response data, le (%u) != rsp_len (%lu), changing SW=%04x to SW=%04x (wrong length)\n",
-				apdu->le, apdu->rsp_len, apdu->sw,
-				SS_SW_ERR_CHECKING_WRONG_LENGTH);
+				apdu->le, apdu->rsp_len, apdu->sw, SS_SW_ERR_CHECKING_WRONG_LENGTH);
 			apdu->sw = SS_SW_ERR_CHECKING_WRONG_LENGTH;
 			apdu->rsp_len = 0;
 		}
 	}
 
 	/* Add length of proactive sim data */
-	if (ctx->proactive.enabled && apdu->sw == 0x9000
-	    && ctx->proactive.data_len)
+	if (ctx->proactive.enabled && apdu->sw == 0x9000 && ctx->proactive.data_len)
 		apdu->sw = 0x9100 | ctx->proactive.data_len;
 
 	if (apdu->rsp_len) {
-		SS_LOGP(SLCHAN, LDEBUG, "Tx R-APDU SW=%04x %s (%lu bytes)\n",
-			apdu->sw, ss_hexdump(apdu->rsp, apdu->rsp_len),
-			apdu->rsp_len);
+		SS_LOGP(SLCHAN, LDEBUG, "Tx R-APDU SW=%04x %s (%lu bytes)\n", apdu->sw,
+			ss_hexdump(apdu->rsp, apdu->rsp_len), apdu->rsp_len);
 	} else {
 		SS_LOGP(SLCHAN, LDEBUG, "Tx R-APDU SW=%04x\n", apdu->sw);
 	}
@@ -341,9 +318,7 @@ out:
 	if (!ss_sw_is_successful(apdu->sw)
 	    /* If the command just fails with "wrong length", it usually didn't change the path */
 	    && (apdu->sw >> 8) != 0x6c) {
-		SS_LOGP(SLCHAN, LINFO,
-			"Unsuccessful response %04x, restoring backup path.\n",
-			apdu->sw);
+		SS_LOGP(SLCHAN, LINFO, "Unsuccessful response %04x, restoring backup path.\n", apdu->sw);
 		assert(apdu->sw >> 8 != 0x61);
 		/* We could apply various levels of smart here:
 		 *
@@ -355,8 +330,7 @@ out:
 		 * computation time barely matters.
 		 */
 		ss_path_reset(&apdu->lchan->fs_path);
-		rc = ss_fs_utils_path_select(&apdu->lchan->fs_path,
-					     &backup_path);
+		rc = ss_fs_utils_path_select(&apdu->lchan->fs_path, &backup_path);
 		if (rc < 0) {
 			SS_LOGP(SLCHAN, LERROR, "Failed to restore path.\n");
 			/* Not taking any further actions -- the SW is already unsuccessful (with
@@ -380,11 +354,9 @@ out:
 		else
 			SS_LOGP(SLCHAN, LDEBUG, " (none)\n");
 	}
-	SS_LOGP(SPROACT, LDEBUG, "proactive sim: %s\n",
-		ctx->proactive.enabled ? "active" : "inactive");
+	SS_LOGP(SPROACT, LDEBUG, "proactive sim: %s\n", ctx->proactive.enabled ? "active" : "inactive");
 
-	SS_LOGP(SLCHAN, LDEBUG,
-		"------------------------- transaction ended -------------------------\n");
+	SS_LOGP(SLCHAN, LDEBUG, "------------------------- transaction ended -------------------------\n");
 	return processed_length;
 }
 
@@ -395,9 +367,8 @@ out:
  *  \param[in] request_buf user provided memory with request APDU.
  *  \param[inout] request_len length of the request APDU.
  *  \returns length of the resulting response APDU. */
-size_t ss_transact(struct ss_context *ctx,
-		   uint8_t *response_buf, size_t response_buf_len,
-		   uint8_t *request_buf, size_t *request_len)
+size_t ss_transact(struct ss_context *ctx, uint8_t *response_buf, size_t response_buf_len, uint8_t *request_buf,
+		   size_t *request_len)
 {
 	/*! Note: The request_len parameter may indicate a request length
 	 *  longer than 5+255 bytes. At return, command_len indicates the true
@@ -412,12 +383,9 @@ size_t ss_transact(struct ss_context *ctx,
 	/* A valid APDU must have a length of at least 5 bytes, any shorter
 	 * APDU counts as invalid and must not be processed any further. */
 	if (_request_len < 5) {
-		SS_LOGP(SIFACE, LERROR, "ignoring short APDU: %s\n",
-			ss_hexdump(request_buf, _request_len));
-		response_buf[response_len++] =
-		    SS_SW_ERR_CHECKING_WRONG_LENGTH >> 8;
-		response_buf[response_len++] =
-		    SS_SW_ERR_CHECKING_WRONG_LENGTH & 0xff;
+		SS_LOGP(SIFACE, LERROR, "ignoring short APDU: %s\n", ss_hexdump(request_buf, _request_len));
+		response_buf[response_len++] = SS_SW_ERR_CHECKING_WRONG_LENGTH >> 8;
+		response_buf[response_len++] = SS_SW_ERR_CHECKING_WRONG_LENGTH & 0xff;
 		return 2;
 	}
 
@@ -431,9 +399,8 @@ size_t ss_transact(struct ss_context *ctx,
 	 * of the request is not yet known and the APDUs come in a concatenated
 	 * list without delimiters or length information. */
 	if (_request_len > sizeof(apdu->cmd) + sizeof(apdu->hdr)) {
-		SS_LOGP(SIFACE, LINFO,
-			"request exceeds maximum length %lu > %lu, will truncate.\n",
-			_request_len, sizeof(apdu->cmd) + sizeof(apdu->hdr));
+		SS_LOGP(SIFACE, LINFO, "request exceeds maximum length %lu > %lu, will truncate.\n", _request_len,
+			sizeof(apdu->cmd) + sizeof(apdu->hdr));
 		_request_len = sizeof(apdu->cmd) + sizeof(apdu->hdr);
 	}
 
@@ -441,8 +408,7 @@ size_t ss_transact(struct ss_context *ctx,
 
 	/* Parse APDU */
 	memcpy(&apdu->hdr, request_buf, sizeof(apdu->hdr));
-	memcpy(apdu->cmd, request_buf + sizeof(apdu->hdr),
-	       _request_len - sizeof(apdu->hdr));
+	memcpy(apdu->cmd, request_buf + sizeof(apdu->hdr), _request_len - sizeof(apdu->hdr));
 
 	/* Note: We cannot determine the apdu->le and apdu->lc fields yet since
 	 * those depend on extra knowledge about the command itsself. We will
@@ -455,9 +421,8 @@ size_t ss_transact(struct ss_context *ctx,
 		if (processed_length != _request_len) {
 			/* This is not necessarily an error -- on the remote file handling side,
 			 * it's pretty much to be expected. */
-			SS_LOGP(SIFACE, LINFO,
-				"Processed %d bytes, but request was %zu\n",
-				processed_length, *request_len);
+			SS_LOGP(SIFACE, LINFO, "Processed %d bytes, but request was %zu\n", processed_length,
+				*request_len);
 		}
 		/* The case switch should have caught that already; ensure things fail hard
 		 * if we accessed uninitialized memory */

--- a/src/softsim/uicc/tlv8.c
+++ b/src/softsim/uicc/tlv8.c
@@ -20,17 +20,17 @@
  * sets how many bytes the buffer pointer (enc) should be be advanced. The
  * parameter "bytes_ahead" sets the minimum valid bytes that the caller expects
  * to be available after the buffer pointer (enc) has been advanced. */
-#define CHECK_AND_ADVANCE(inc, bytes_ahead) \
-	if (len < bytes_used + inc + bytes_ahead) { \
-		SS_LOGP(STLV8, LDEBUG, "exceeding buffer bounds: len=%zu, inc=%zu, bytes_ahead=%zu, cannot decode IE\n", \
-			len, (size_t) inc, (size_t) bytes_ahead); \
-		return NULL; \
-	} \
-	bytes_used+=inc; \
-	enc+=inc \
+#define CHECK_AND_ADVANCE(inc, bytes_ahead)                                                                    \
+	if (len < bytes_used + inc + bytes_ahead) {                                                            \
+		SS_LOGP(STLV8, LDEBUG,                                                                         \
+			"exceeding buffer bounds: len=%zu, inc=%zu, bytes_ahead=%zu, cannot decode IE\n", len, \
+			(size_t)inc, (size_t)bytes_ahead);                                                     \
+		return NULL;                                                                                   \
+	}                                                                                                      \
+	bytes_used += inc;                                                                                     \
+	enc += inc
 
-static struct tlv8_ie *decode_ie(size_t *used_len, const uint8_t *enc,
-				 size_t len)
+static struct tlv8_ie *decode_ie(size_t *used_len, const uint8_t *enc, size_t len)
 {
 	struct tlv8_ie ie;
 	struct tlv8_ie *ie_ret;
@@ -93,10 +93,8 @@ struct ss_list *ss_tlv8_decode(const uint8_t *enc, size_t len)
 		} else if (remaining_len > 0) {
 			for (i = used_len; i < used_len + remaining_len; ++i) {
 				if (enc[i] != 0xff) {
-					SS_LOGP(STLV8, LERROR,
-						"Error decoding TLV8 (%s).\n",
-						ss_hexdump(&enc[used_len],
-							   remaining_len));
+					SS_LOGP(STLV8, LERROR, "Error decoding TLV8 (%s).\n",
+						ss_hexdump(&enc[used_len], remaining_len));
 					ss_tlv8_free(list);
 					return NULL;
 				}
@@ -111,8 +109,7 @@ struct ss_list *ss_tlv8_decode(const uint8_t *enc, size_t len)
 	return list;
 }
 
-static void dump_ie(struct tlv8_ie *ie, uint8_t indent,
-		    enum log_subsys subsys, enum log_level level)
+static void dump_ie(struct tlv8_ie *ie, uint8_t indent, enum log_subsys subsys, enum log_level level)
 {
 	char indent_str[256];
 	char *value_str;
@@ -137,8 +134,7 @@ static void dump_ie(struct tlv8_ie *ie, uint8_t indent,
 		delimiter = ' ';
 	}
 
-	SS_LOGP(subsys, level, "%s(tag=0x%02x, len=%zu)%c %s\n", indent_str,
-		ie->tag, value_len, delimiter, value_str);
+	SS_LOGP(subsys, level, "%s(tag=0x%02x, len=%zu)%c %s\n", indent_str, ie->tag, value_len, delimiter, value_str);
 }
 
 /*! Dump decoded TLV8 data.
@@ -146,8 +142,7 @@ static void dump_ie(struct tlv8_ie *ie, uint8_t indent,
  *  \param[in] indent indentation level of the generated output.
  *  \param[in] log_subsys log subsystem to generate the output for.
  *  \param[in] log_level log level to generate the output for. */
-void ss_tlv8_dump(const struct ss_list *list, uint8_t indent,
-		  enum log_subsys log_subsys, enum log_level log_level)
+void ss_tlv8_dump(const struct ss_list *list, uint8_t indent, enum log_subsys log_subsys, enum log_level log_level)
 {
 	struct tlv8_ie *ie;
 
@@ -200,8 +195,7 @@ void ss_tlv8_free(struct ss_list *list)
  *  \param[in] len TLV8 value length.
  *  \param[in] value pointer to TLV8 value (data is copied).
  *  \returns pointer to allocated IE struct. */
-struct tlv8_ie *ss_tlv8_new_ie(struct ss_list *list, uint8_t tag, size_t len,
-			       const uint8_t *value)
+struct tlv8_ie *ss_tlv8_new_ie(struct ss_list *list, uint8_t tag, size_t len, const uint8_t *value)
 {
 	struct tlv8_ie *ie = SS_ALLOC(struct tlv8_ie);
 
@@ -244,8 +238,7 @@ struct tlv8_ie *ss_tlv8_get_ie(const struct ss_list *list, uint8_t tag)
  *  \param[in] tag TLV8 tag to look for.
  *  \param[in] min_len minimum required length.
  *  \returns pointer to IE struct on success, NULL if IE is not found. */
-struct tlv8_ie *ss_tlv8_get_ie_minlen(const struct ss_list *list, uint8_t tag,
-				      size_t min_len)
+struct tlv8_ie *ss_tlv8_get_ie_minlen(const struct ss_list *list, uint8_t tag, size_t min_len)
 {
 	struct tlv8_ie *ie = ss_tlv8_get_ie(list, tag);
 	if (!ie)
@@ -264,9 +257,7 @@ static size_t encode_ie(uint8_t *enc, size_t len, struct tlv8_ie *ie)
 	/* Do not encode anything when we are unable to determine the length
 	 * or when the predicted length exceeds the buffer. */
 	if (ie_len == 0 || ie_len > len) {
-		SS_LOGP(STLV8, LERROR,
-			"not enough buffer space to encode TLV string, aborting at IE %02x.\n",
-			ie->tag);
+		SS_LOGP(STLV8, LERROR, "not enough buffer space to encode TLV string, aborting at IE %02x.\n", ie->tag);
 		return 0;
 	}
 

--- a/src/softsim/uicc/uicc_admin.c
+++ b/src/softsim/uicc/uicc_admin.c
@@ -37,22 +37,16 @@ static int fix_short_fd(struct ss_list *fcp_decoded_envelope)
 	uint8_t number_of_records;
 	int rc;
 
-	fcp_ie_fd =
-	    ss_btlv_get_ie_minlen(fcp_decoded_envelope,
-				  TS_102_221_IEI_FCP_FILE_DESCR, 2);
+	fcp_ie_fd = ss_btlv_get_ie_minlen(fcp_decoded_envelope, TS_102_221_IEI_FCP_FILE_DESCR, 2);
 	if (!fcp_ie_fd) {
-		SS_LOGP(SADMIN, LERROR,
-			"invalid FCP: no file descriptor (%02X), cannot fix!\n",
+		SS_LOGP(SADMIN, LERROR, "invalid FCP: no file descriptor (%02X), cannot fix!\n",
 			TS_102_221_IEI_FCP_FILE_DESCR);
 		rc = -EINVAL;
 	}
 
-	fcp_ie_file_size =
-	    ss_btlv_get_ie_minlen(fcp_decoded_envelope,
-				  TS_102_221_IEI_FCP_FILE_SIZE, 1);
+	fcp_ie_file_size = ss_btlv_get_ie_minlen(fcp_decoded_envelope, TS_102_221_IEI_FCP_FILE_SIZE, 1);
 	if (!fcp_ie_file_size) {
-		SS_LOGP(SADMIN, LERROR,
-			"invalid FCP: short file descr -- no size IE (%02X), cannot fix!\n",
+		SS_LOGP(SADMIN, LERROR, "invalid FCP: short file descr -- no size IE (%02X), cannot fix!\n",
 			TS_102_221_IEI_FCP_FILE_SIZE);
 		rc = -EINVAL;
 	}
@@ -63,53 +57,44 @@ static int fix_short_fd(struct ss_list *fcp_decoded_envelope)
 	if (fcp_ie_fd->value->len == 4) {
 		/* extend the length of the file descriptor length */
 		fd_fixed = ss_buf_alloc(5);
-		memcpy(fd_fixed->data, fcp_ie_fd->value->data,
-		       fcp_ie_fd->value->len);
+		memcpy(fd_fixed->data, fcp_ie_fd->value->data, fcp_ie_fd->value->len);
 		fd_fixed->data[4] = 0x00;
 
 		/* we should now be able to decode the file descriptor */
 		rc = ss_fcp_dec_file_descr(&fd_decoded, fd_fixed);
 		if (rc < 0) {
 			ss_buf_free(fd_fixed);
-			SS_LOGP(SADMIN, LERROR,
-				"invalid FCP: short file descr -- cannot fix!\n");
+			SS_LOGP(SADMIN, LERROR, "invalid FCP: short file descr -- cannot fix!\n");
 			return -EINVAL;
 		}
 
 		/* make sure the file descriptor is indeed describing a record
 		 * oriented file */
-		if (fd_decoded.structure != SS_FCP_LINEAR_FIXED &&
-		    fd_decoded.structure != SS_FCP_CYCLIC) {
+		if (fd_decoded.structure != SS_FCP_LINEAR_FIXED && fd_decoded.structure != SS_FCP_CYCLIC) {
 			ss_buf_free(fd_fixed);
-			SS_LOGP(SADMIN, LERROR,
-				"invalid FCP: short file descr -- cannot fix!\n");
+			SS_LOGP(SADMIN, LERROR, "invalid FCP: short file descr -- cannot fix!\n");
 			return -EINVAL;
 		}
 
 		/* calculate missing number of records */
-		file_size =
-		    ss_uint32_from_array(fcp_ie_file_size->value->data,
-					 fcp_ie_file_size->value->len);
+		file_size = ss_uint32_from_array(fcp_ie_file_size->value->data, fcp_ie_file_size->value->len);
 		number_of_records = file_size / fd_decoded.record_len;
 		if (number_of_records > 254)
 			number_of_records = 254;
 		else
-			number_of_records = (uint8_t) number_of_records;
+			number_of_records = (uint8_t)number_of_records;
 		fd_fixed->data[4] = number_of_records;
 
 		/* replace fd in TLV structure */
 		ss_buf_free(fcp_ie_fd->value);
 		fcp_ie_fd->value = fd_fixed;
 
-		SS_LOGP(SADMIN, LERROR,
-			"invalid FCP: short file descr -- fixed (%s)\n",
-			ss_hexdump(fcp_ie_fd->value->data,
-				   fcp_ie_fd->value->len));
+		SS_LOGP(SADMIN, LERROR, "invalid FCP: short file descr -- fixed (%s)\n",
+			ss_hexdump(fcp_ie_fd->value->data, fcp_ie_fd->value->len));
 		return 0;
 	}
 
-	SS_LOGP(SADMIN, LERROR,
-		"invalid FCP: short file descr -- cannot fix!\n");
+	SS_LOGP(SADMIN, LERROR, "invalid FCP: short file descr -- cannot fix!\n");
 	return -EINVAL;
 }
 
@@ -131,19 +116,14 @@ static int validate_fcp(struct ss_list *fcp_decoded_envelope)
 		return -EINVAL;
 	}
 
-	fcp_ie =
-	    ss_btlv_get_ie_minlen(fcp_decoded_envelope,
-				  TS_102_221_IEI_FCP_FILE_DESCR, 2);
+	fcp_ie = ss_btlv_get_ie_minlen(fcp_decoded_envelope, TS_102_221_IEI_FCP_FILE_DESCR, 2);
 	if (!fcp_ie) {
-		SS_LOGP(SADMIN, LERROR,
-			"invalid FCP: no file descriptor (%02X)\n",
-			TS_102_221_IEI_FCP_FILE_DESCR);
+		SS_LOGP(SADMIN, LERROR, "invalid FCP: no file descriptor (%02X)\n", TS_102_221_IEI_FCP_FILE_DESCR);
 		rc = -EINVAL;
 	} else {
 		rc = ss_fcp_dec_file_descr(&file_descr, fcp_ie->value);
 		if (rc < 0) {
-			SS_LOGP(SADMIN, LERROR,
-				"invalid FCP: unable to decode file descriptor -- trying to fix (%s)\n",
+			SS_LOGP(SADMIN, LERROR, "invalid FCP: unable to decode file descriptor -- trying to fix (%s)\n",
 				ss_hexdump(fcp_ie->value->data, fcp_ie->value->len));
 			rc = fix_short_fd(fcp_decoded_envelope);
 			if (rc < 0)
@@ -153,56 +133,41 @@ static int validate_fcp(struct ss_list *fcp_decoded_envelope)
 		}
 	}
 
-	fcp_ie =
-	    ss_btlv_get_ie_minlen(fcp_decoded_envelope,
-				  TS_102_221_IEI_FCP_FILE_ID, 2);
+	fcp_ie = ss_btlv_get_ie_minlen(fcp_decoded_envelope, TS_102_221_IEI_FCP_FILE_ID, 2);
 	if (!fcp_ie) {
-		SS_LOGP(SADMIN, LERROR,
-			"invalid FCP: no file identifier (%02X)\n",
-			TS_102_221_IEI_FCP_FILE_ID);
+		SS_LOGP(SADMIN, LERROR, "invalid FCP: no file identifier (%02X)\n", TS_102_221_IEI_FCP_FILE_ID);
 		rc = -EINVAL;
 	}
 
-	fcp_ie =
-	    ss_btlv_get_ie_minlen(fcp_decoded_envelope,
-				  TS_102_221_IEI_FCP_LIFE_CYCLE_ST, 1);
+	fcp_ie = ss_btlv_get_ie_minlen(fcp_decoded_envelope, TS_102_221_IEI_FCP_LIFE_CYCLE_ST, 1);
 	if (!fcp_ie) {
-		SS_LOGP(SADMIN, LERROR,
-			"invalid FCP: no file lifecycle status byte (%02X)\n",
+		SS_LOGP(SADMIN, LERROR, "invalid FCP: no file lifecycle status byte (%02X)\n",
 			TS_102_221_IEI_FCP_LIFE_CYCLE_ST);
 		rc = -EINVAL;
 	}
 
 	/* we don't support compact or expanded security attributes */
-	if (ss_btlv_get_ie(fcp_decoded_envelope, TS_102_221_IEI_FCP_SEC_ATTR_8C)
-	    || ss_btlv_get_ie(fcp_decoded_envelope,
-			      TS_102_221_IEI_FCP_SEC_ATTR_AB)) {
+	if (ss_btlv_get_ie(fcp_decoded_envelope, TS_102_221_IEI_FCP_SEC_ATTR_8C) ||
+	    ss_btlv_get_ie(fcp_decoded_envelope, TS_102_221_IEI_FCP_SEC_ATTR_AB)) {
 		SS_LOGP(SADMIN, LERROR,
 			"invalid FCP: compact or expanded security rules not supported (%02X || %02X)\n",
-			TS_102_221_IEI_FCP_SEC_ATTR_8C,
-			TS_102_221_IEI_FCP_SEC_ATTR_AB);
+			TS_102_221_IEI_FCP_SEC_ATTR_8C, TS_102_221_IEI_FCP_SEC_ATTR_AB);
 		rc = -EINVAL;
 	}
 
 	/* we must have referenced security attributes */
-	fcp_ie =
-	    ss_btlv_get_ie(fcp_decoded_envelope, TS_102_221_IEI_FCP_SEC_ATTR_8B);
+	fcp_ie = ss_btlv_get_ie(fcp_decoded_envelope, TS_102_221_IEI_FCP_SEC_ATTR_8B);
 	if (!fcp_ie) {
-		SS_LOGP(SADMIN, LERROR,
-			"invalid FCP: no referenced security attributes (%02X)\n",
+		SS_LOGP(SADMIN, LERROR, "invalid FCP: no referenced security attributes (%02X)\n",
 			TS_102_221_IEI_FCP_SEC_ATTR_8B);
 		rc = -EINVAL;
 	}
 
 	switch (file_descr.type) {
 	case SS_FCP_WORKING_EF:
-		fcp_ie =
-		    ss_btlv_get_ie_minlen(fcp_decoded_envelope,
-					  TS_102_221_IEI_FCP_FILE_SIZE, 1);
+		fcp_ie = ss_btlv_get_ie_minlen(fcp_decoded_envelope, TS_102_221_IEI_FCP_FILE_SIZE, 1);
 		if (!fcp_ie) {
-			SS_LOGP(SADMIN, LERROR,
-				"invalid FCP: no size (%02X)\n",
-				TS_102_221_IEI_FCP_FILE_SIZE);
+			SS_LOGP(SADMIN, LERROR, "invalid FCP: no size (%02X)\n", TS_102_221_IEI_FCP_FILE_SIZE);
 			rc = -EINVAL;
 		}
 
@@ -211,29 +176,22 @@ static int validate_fcp(struct ss_list *fcp_decoded_envelope)
 		case SS_FCP_LINEAR_FIXED:
 			break;
 		default:
-			SS_LOGP(SADMIN, LERROR,
-				"invalid FCP: unsupported file struture (%u)\n",
-				file_descr.structure);
+			SS_LOGP(SADMIN, LERROR, "invalid FCP: unsupported file struture (%u)\n", file_descr.structure);
 			rc = -EINVAL;
 		}
 
 		break;
 	case SS_FCP_DF_OR_ADF:
-		fcp_ie =
-		    ss_btlv_get_ie(fcp_decoded_envelope,
-				   TS_102_221_IEI_FCP_PIN_STAT_TMPL);
+		fcp_ie = ss_btlv_get_ie(fcp_decoded_envelope, TS_102_221_IEI_FCP_PIN_STAT_TMPL);
 		if (fcp_ie) {
-			SS_LOGP(SADMIN, LERROR,
-				"FCP needlessly contains pin status template (%02X)\n",
+			SS_LOGP(SADMIN, LERROR, "FCP needlessly contains pin status template (%02X)\n",
 				TS_102_221_IEI_FCP_PIN_STAT_TMPL);
 			rc = -EINVAL;
 		}
 
 		break;
 	default:
-		SS_LOGP(SADMIN, LERROR,
-			"invalid FCP: unsupported file type (%u)\n",
-			file_descr.type);
+		SS_LOGP(SADMIN, LERROR, "invalid FCP: unsupported file type (%u)\n", file_descr.type);
 		rc = -EINVAL;
 	}
 
@@ -294,7 +252,7 @@ int ss_uicc_admin_cmd_create_file(struct ss_apdu *apdu)
 	/* Extract fid */
 	fcp_tmpl_ie = ss_btlv_get_ie(fcp_decoded, TS_102_221_IEI_FCP_TMPL);
 	if (!fcp_tmpl_ie) {
-		SS_LOGP(SADMIN, LERROR,	"missing FCP template -- cannot create file\n");
+		SS_LOGP(SADMIN, LERROR, "missing FCP template -- cannot create file\n");
 		goto err_inval;
 	}
 
@@ -304,44 +262,34 @@ int ss_uicc_admin_cmd_create_file(struct ss_apdu *apdu)
 		goto err_inval;
 	}
 
-	fcp_fid_ie =
-	    ss_btlv_get_ie_minlen(fcp_tmpl_ie->nested,
-				  TS_102_221_IEI_FCP_FILE_ID, 2);
+	fcp_fid_ie = ss_btlv_get_ie_minlen(fcp_tmpl_ie->nested, TS_102_221_IEI_FCP_FILE_ID, 2);
 	if (!fcp_fid_ie) {
 		SS_LOGP(SADMIN, LERROR, "unable to decode FCP template -- cannot create file\n");
 		goto err_inval;
 	}
-	fid =
-	    ss_uint32_from_array(fcp_fid_ie->value->data,
-				 fcp_fid_ie->value->len);
+	fid = ss_uint32_from_array(fcp_fid_ie->value->data, fcp_fid_ie->value->len);
 
 	/* Extract description to determine type (EF or DF) to decide which
 	 * access rules to apply */
 	/* FIXME #57: After FID decoding, this is the second step that is performed
 	 * twice, here and in ss_fs_create; consider refactoring. */
-	fcp_file_descr_ie =
-	    ss_btlv_get_ie_minlen(fcp_tmpl_ie->nested,
-				  TS_102_221_IEI_FCP_FILE_DESCR, 2);
+	fcp_file_descr_ie = ss_btlv_get_ie_minlen(fcp_tmpl_ie->nested, TS_102_221_IEI_FCP_FILE_DESCR, 2);
 	if (!fcp_file_descr_ie) {
-		SS_LOGP(SADMIN, LERROR,	"missing FILE DESCR template -- cannot create file\n");
+		SS_LOGP(SADMIN, LERROR, "missing FILE DESCR template -- cannot create file\n");
 		goto err_inval;
 	}
 	if (ss_fcp_dec_file_descr(&file_descr, fcp_file_descr_ie->value) < 0) {
-		SS_LOGP(SADMIN, LERROR,	"malformed FILE DESCR template -- cannot create file\n");
+		SS_LOGP(SADMIN, LERROR, "malformed FILE DESCR template -- cannot create file\n");
 		goto err_inval;
 	}
 
-	SS_LOGP(SADMIN, LDEBUG,	"file descriptor:\n");
+	SS_LOGP(SADMIN, LDEBUG, "file descriptor:\n");
 	ss_fcp_dump_file_descr(&file_descr, 1, SFILE, LDEBUG);
 
 	rewind_to_df(apdu);
 
-	if (!ss_access_check_command(apdu,
-				file_descr.type == SS_FCP_DF_OR_ADF ?
-				SS_ACCESS_INTENTION_DF_CREATE_DF :
-				SS_ACCESS_INTENTION_DF_CREATE_EF
-				))
-	{
+	if (!ss_access_check_command(apdu, file_descr.type == SS_FCP_DF_OR_ADF ? SS_ACCESS_INTENTION_DF_CREATE_DF :
+										 SS_ACCESS_INTENTION_DF_CREATE_EF)) {
 		ss_btlv_free(fcp_decoded);
 		return SS_SW_ERR_CMD_NOT_ALLOWED_NO_INFO;
 	}
@@ -350,7 +298,7 @@ int ss_uicc_admin_cmd_create_file(struct ss_apdu *apdu)
 
 	fcp_reencoded = ss_btlv_encode_to_ss_buf(fcp_decoded);
 	if (!fcp_reencoded) {
-		SS_LOGP(SADMIN, LERROR,	"unable to reencode FCP -- cannot create file\n");
+		SS_LOGP(SADMIN, LERROR, "unable to reencode FCP -- cannot create file\n");
 		goto err_inval;
 	}
 
@@ -458,8 +406,7 @@ int ss_uicc_admin_cmd_activate_file(struct ss_apdu *apdu)
 
 	struct ber_tlv_ie *fcp_decoded_lifecycle;
 	struct ss_file *selected_file = ss_get_file_from_path(&apdu->lchan->fs_path);
-	fcp_decoded_lifecycle =
-		ss_btlv_get_ie_minlen(selected_file->fcp_decoded, TS_102_221_IEI_FCP_LIFE_CYCLE_ST, 1);
+	fcp_decoded_lifecycle = ss_btlv_get_ie_minlen(selected_file->fcp_decoded, TS_102_221_IEI_FCP_LIFE_CYCLE_ST, 1);
 	fcp_decoded_lifecycle->value->data[0] = 0x05;
 
 	/* Store encoded FCP again */

--- a/src/softsim/uicc/uicc_auth.c
+++ b/src/softsim/uicc/uicc_auth.c
@@ -24,12 +24,12 @@
 
 /* 3GPP TS 31.102 Table 7.1.2-1 + Table 7.1.2-2 */
 enum usim_auth_ctx {
-	USIM_AUTH_CTX_GSM	= 0,
-	USIM_AUTH_CTX_3G	= 1,
-	USIM_AUTH_CTX_VGCS_VBS	= 2,
-	USIM_AUTH_CTX_GBA	= 4,
-	USIM_AUTH_CTX_MBMS	= 5,
-	USIM_AUTH_CTX_LOCAL_KEY	= 6,
+	USIM_AUTH_CTX_GSM = 0,
+	USIM_AUTH_CTX_3G = 1,
+	USIM_AUTH_CTX_VGCS_VBS = 2,
+	USIM_AUTH_CTX_GBA = 4,
+	USIM_AUTH_CTX_MBMS = 5,
+	USIM_AUTH_CTX_LOCAL_KEY = 6,
 };
 
 /* convenience struct for the response APDU */
@@ -45,7 +45,7 @@ struct auth_res_success_3g {
 	 * needs to be set when configuring the file system. */
 	uint8_t kc_len;
 	uint8_t kc[8];
-} __attribute__ ((packed));
+} __attribute__((packed));
 
 #define KEY_DATA_FID 0xA001
 #define SEQ_DATA_FID 0xA002
@@ -64,27 +64,21 @@ static int get_key_data(struct milenage_key_data *key_data)
 	ss_fs_init(&key_data_path);
 	rc = ss_fs_select(&key_data_path, KEY_DATA_FID);
 	if (rc < 0) {
-		SS_LOGP(SAUTH, LERROR,
-			"key data file (%04x) not found -- abort\n",
-			KEY_DATA_FID);
+		SS_LOGP(SAUTH, LERROR, "key data file (%04x) not found -- abort\n", KEY_DATA_FID);
 		ss_path_reset(&key_data_path);
 		return -EINVAL;
 	}
 
-	key_data_raw =
-	    ss_storage_read_file(&key_data_path, 0,
-				 ss_storage_get_file_len(&key_data_path));
+	key_data_raw = ss_storage_read_file(&key_data_path, 0, ss_storage_get_file_len(&key_data_path));
 	if (!key_data_raw) {
-		SS_LOGP(SAUTH, LERROR,
-			"key data file (%s) not readable -- abort\n",
+		SS_LOGP(SAUTH, LERROR, "key data file (%s) not readable -- abort\n",
 			ss_fs_utils_dump_path(&key_data_path));
 		ss_path_reset(&key_data_path);
 		return -EINVAL;
 	}
 
 	if (key_data_raw->len < sizeof(key_data->k) + sizeof(key_data->opc) + 1) {
-		SS_LOGP(SAUTH, LERROR,
-			"key data file (%s) too short -- abort\n",
+		SS_LOGP(SAUTH, LERROR, "key data file (%s) too short -- abort\n",
 			ss_fs_utils_dump_path(&key_data_path));
 		ss_path_reset(&key_data_path);
 		ss_buf_free(key_data_raw);
@@ -92,16 +86,13 @@ static int get_key_data(struct milenage_key_data *key_data)
 	}
 
 	memcpy(key_data->k, key_data_raw->data, sizeof(key_data->k));
-	memcpy(key_data->opc, key_data_raw->data + sizeof(key_data->k),
-	       sizeof(key_data->opc));
-	if (key_data_raw->data[sizeof(key_data->k) + sizeof(key_data->opc)] ==
-	    0x01)
+	memcpy(key_data->opc, key_data_raw->data + sizeof(key_data->k), sizeof(key_data->opc));
+	if (key_data_raw->data[sizeof(key_data->k) + sizeof(key_data->opc)] == 0x01)
 		key_data->opc_is_op = true;
 	else
 		key_data->opc_is_op = false;
 
-	SS_LOGP(SAUTH, LDEBUG, "key data file (%s) loaded\n",
-		ss_fs_utils_dump_path(&key_data_path));
+	SS_LOGP(SAUTH, LDEBUG, "key data file (%s) loaded\n", ss_fs_utils_dump_path(&key_data_path));
 
 	ss_path_reset(&key_data_path);
 	ss_buf_free(key_data_raw);
@@ -123,27 +114,21 @@ static int get_seq_data(struct milenage_seq_data *seq_data)
 	ss_fs_init(&seq_data_path);
 	rc = ss_fs_select(&seq_data_path, SEQ_DATA_FID);
 	if (rc < 0) {
-		SS_LOGP(SAUTH, LERROR,
-			"seq data file (%04x) not found -- abort\n",
-			KEY_DATA_FID);
+		SS_LOGP(SAUTH, LERROR, "seq data file (%04x) not found -- abort\n", KEY_DATA_FID);
 		ss_path_reset(&seq_data_path);
 		return -EINVAL;
 	}
 
-	seq_data_raw =
-	    ss_storage_read_file(&seq_data_path, 0,
-				 ss_storage_get_file_len(&seq_data_path));
+	seq_data_raw = ss_storage_read_file(&seq_data_path, 0, ss_storage_get_file_len(&seq_data_path));
 	if (!seq_data_raw) {
-		SS_LOGP(SAUTH, LERROR,
-			"seq data file (%s) not readable -- abort\n",
+		SS_LOGP(SAUTH, LERROR, "seq data file (%s) not readable -- abort\n",
 			ss_fs_utils_dump_path(&seq_data_path));
 		ss_path_reset(&seq_data_path);
 		return -EINVAL;
 	}
 
 	if (seq_data_raw->len < sizeof(seq_data->seq) + sizeof(seq_data->delta)) {
-		SS_LOGP(SAUTH, LERROR,
-			"seq data file (%s) too short -- abort\n",
+		SS_LOGP(SAUTH, LERROR, "seq data file (%s) too short -- abort\n",
 			ss_fs_utils_dump_path(&seq_data_path));
 		ss_path_reset(&seq_data_path);
 		ss_buf_free(seq_data_raw);
@@ -154,8 +139,7 @@ static int get_seq_data(struct milenage_seq_data *seq_data)
 		seq_data->seq[i] = ss_uint64_load_from_be(&seq_data_raw->data[i * 8]);
 	seq_data->delta = ss_uint64_load_from_be(&seq_data_raw->data[SS_ARRAY_SIZE(seq_data->seq) * 8]);
 
-	SS_LOGP(SAUTH, LDEBUG, "seq data file (%s) loaded\n",
-		ss_fs_utils_dump_path(&seq_data_path));
+	SS_LOGP(SAUTH, LDEBUG, "seq data file (%s) loaded\n", ss_fs_utils_dump_path(&seq_data_path));
 	ss_path_reset(&seq_data_path);
 	ss_buf_free(seq_data_raw);
 	return 0;
@@ -171,9 +155,7 @@ static int update_seq_data(struct milenage_seq_data *seq_data)
 	ss_fs_init(&seq_data_path);
 	rc = ss_fs_select(&seq_data_path, SEQ_DATA_FID);
 	if (rc < 0) {
-		SS_LOGP(SAUTH, LERROR,
-			"seq data file (%04x) not found -- abort\n",
-			KEY_DATA_FID);
+		SS_LOGP(SAUTH, LERROR, "seq data file (%04x) not found -- abort\n", KEY_DATA_FID);
 		ss_path_reset(&seq_data_path);
 		return -EINVAL;
 	}
@@ -182,18 +164,15 @@ static int update_seq_data(struct milenage_seq_data *seq_data)
 		ss_uint64_store_to_be(&seq_data_raw[i * 8], seq_data->seq[i]);
 	ss_uint64_store_to_be(&seq_data_raw[SS_ARRAY_SIZE(seq_data->seq) * 8], seq_data->delta);
 
-	rc = ss_storage_write_file(&seq_data_path, seq_data_raw, 0,
-				   sizeof(seq_data_raw));
+	rc = ss_storage_write_file(&seq_data_path, seq_data_raw, 0, sizeof(seq_data_raw));
 	if (rc < 0) {
-		SS_LOGP(SAUTH, LERROR,
-			"seq data file (%s) not writeable -- abort\n",
+		SS_LOGP(SAUTH, LERROR, "seq data file (%s) not writeable -- abort\n",
 			ss_fs_utils_dump_path(&seq_data_path));
 		ss_path_reset(&seq_data_path);
 		return -EINVAL;
 	}
 
-	SS_LOGP(SAUTH, LDEBUG, "seq data file (%s) updated\n",
-		ss_fs_utils_dump_path(&seq_data_path));
+	SS_LOGP(SAUTH, LDEBUG, "seq data file (%s) updated\n", ss_fs_utils_dump_path(&seq_data_path));
 	ss_path_reset(&seq_data_path);
 	return 0;
 }
@@ -209,9 +188,8 @@ static int gen_opc(uint8_t *opc, const struct milenage_key_data *akd)
 	}
 }
 
-static int authenticate_milenage(struct ss_apdu *apdu, enum usim_auth_ctx auth_ctx,
-				 const uint8_t *rand, uint8_t rand_len,
-				 const uint8_t *autn, uint8_t autn_len)
+static int authenticate_milenage(struct ss_apdu *apdu, enum usim_auth_ctx auth_ctx, const uint8_t *rand,
+				 uint8_t rand_len, const uint8_t *autn, uint8_t autn_len)
 {
 	struct milenage_key_data mkd_storage;
 	struct milenage_key_data *mkd = &mkd_storage;
@@ -236,27 +214,27 @@ static int authenticate_milenage(struct ss_apdu *apdu, enum usim_auth_ctx auth_c
 
 	switch (auth_ctx) {
 	case USIM_AUTH_CTX_GSM:
-		if (rand_len != 128/8) {
+		if (rand_len != 128 / 8) {
 			SS_LOGP(SAUTH, LERROR, "unexpected RAND len -- authentication failed\n");
 			goto out_err;
 		}
 		/* actually perform authentication */
-		rc = gsm_milenage(opc, mkd->k, rand, &apdu->rsp[1], &apdu->rsp[1+4+1]);
+		rc = gsm_milenage(opc, mkd->k, rand, &apdu->rsp[1], &apdu->rsp[1 + 4 + 1]);
 		if (rc < 0) {
 			SS_LOGP(SAUTH, LERROR, "milenage computation failed -- authentication failed\n");
 			goto out_err;
 		}
 		/* put together response data */
-		apdu->rsp[0] = 4; 	/* length of SRES */
-		apdu->rsp[1+4] = 8;	/* length of Kc */
+		apdu->rsp[0] = 4;     /* length of SRES */
+		apdu->rsp[1 + 4] = 8; /* length of Kc */
 		apdu->rsp_len = 1 + 4 + 1 + 8;
 		break;
 	case USIM_AUTH_CTX_3G:
-		if (rand_len != 128/8) {
+		if (rand_len != 128 / 8) {
 			SS_LOGP(SAUTH, LERROR, "unexpected RAND len -- authentication failed\n");
 			goto out_err;
 		}
-		if (autn_len != 128/8) {
+		if (autn_len != 128 / 8) {
 			SS_LOGP(SAUTH, LERROR, "unexpected AUTN len -- authentication failed\n");
 			goto out_err;
 		}
@@ -268,7 +246,7 @@ static int authenticate_milenage(struct ss_apdu *apdu, enum usim_auth_ctx auth_c
 			assert(mres.res_len == 8);
 			/* FIXME #59: update SEQ bucket for IND */
 			/* generate response */
-			res_3g = (struct auth_res_success_3g *) apdu->rsp;
+			res_3g = (struct auth_res_success_3g *)apdu->rsp;
 			res_3g->tag = 0xDB;
 			res_3g->res_len = mres.res_len;
 			memcpy(res_3g->res, mres.res, mres.res_len);
@@ -353,11 +331,11 @@ int ss_uicc_auth_cmd_authenticate_even_fn(struct ss_apdu *apdu)
 	if (auth_ctx == USIM_AUTH_CTX_3G) {
 		if (apdu->lc < 1 + rand_len + 1)
 			goto err_len;
-		autn_len = apdu->cmd[1+rand_len];
+		autn_len = apdu->cmd[1 + rand_len];
 
 		if (apdu->lc < 1 + rand_len + 1 + autn_len)
 			goto err_len;
-		autn = &apdu->cmd[1+rand_len+1];
+		autn = &apdu->cmd[1 + rand_len + 1];
 	} else {
 		autn_len = 0;
 		autn = NULL;

--- a/src/softsim/uicc/uicc_cat.c
+++ b/src/softsim/uicc/uicc_cat.c
@@ -47,23 +47,20 @@ int handle_sms_pp_dwnld(struct ss_apdu *apdu, struct ss_buf *cat_template)
 
 	ctlv_data = ss_ctlv_decode(cat_template->data, cat_template->len);
 	if (!ctlv_data) {
-		SS_LOGP(SPROACT, LERROR,
-			"failed to decode COMPREHENSION-TLV encoded SMS-PP data\n");
+		SS_LOGP(SPROACT, LERROR, "failed to decode COMPREHENSION-TLV encoded SMS-PP data\n");
 		return SS_SW_ERR_WRONG_PARAM_INCORRECT_DATA;
 	}
 	ss_ctlv_dump(ctlv_data, 2, SPROACT, LDEBUG);
 
 	sms_tpdu_ie = ss_ctlv_get_ie(ctlv_data, TS_101_220_IEI_SMS_TPDU);
 	if (!sms_tpdu_ie) {
-		SS_LOGP(SPROACT, LERROR,
-			"failed to receive SMS-PP, SMS-TPDU IE missing\n");
+		SS_LOGP(SPROACT, LERROR, "failed to receive SMS-PP, SMS-TPDU IE missing\n");
 		rc = SS_SW_ERR_WRONG_PARAM_INCORRECT_DATA;
 		goto leave;
 	}
 
 	apdu->rsp_len = SS_ARRAY_SIZE(apdu->rsp);
-	rc = ss_uicc_sms_rx(apdu->ctx,
-			    sms_tpdu_ie->value, &apdu->rsp_len, apdu->rsp);
+	rc = ss_uicc_sms_rx(apdu->ctx, sms_tpdu_ie->value, &apdu->rsp_len, apdu->rsp);
 	if (rc != 0)
 		apdu->rsp_len = 0;
 
@@ -87,8 +84,7 @@ int ss_uicc_cat_cmd_term_profile(struct ss_apdu *apdu)
 	size_t term_profile_len;
 
 	/* Clear old profile */
-	memset(apdu->ctx->proactive.term_profile, 0,
-	       sizeof(apdu->ctx->proactive.term_profile));
+	memset(apdu->ctx->proactive.term_profile, 0, sizeof(apdu->ctx->proactive.term_profile));
 
 	/* Store profile */
 	if (apdu->lc <= sizeof(apdu->ctx->proactive.term_profile)) {
@@ -96,8 +92,7 @@ int ss_uicc_cat_cmd_term_profile(struct ss_apdu *apdu)
 	} else {
 		/* Note: the buffer size is chosen large enough, so that this
 		 * error should never occur. */
-		SS_LOGP(SPROACT, LERROR,
-			"transmitted TERMINAL PROFILE too large for internal buffer\n");
+		SS_LOGP(SPROACT, LERROR, "transmitted TERMINAL PROFILE too large for internal buffer\n");
 		term_profile_len = sizeof(apdu->ctx->proactive.term_profile);
 	}
 	memcpy(apdu->ctx->proactive.term_profile, apdu->cmd, term_profile_len);
@@ -124,11 +119,9 @@ int ss_uicc_cat_cmd_envelope(struct ss_apdu *apdu)
 		SS_LOGP(SPROACT, LERROR, "Data length anounced in P3 exceeds available data\n");
 		return SS_SW_ERR_WRONG_PARAM_INCORRECT_DATA;
 	}
-	envelope =
-	    ss_btlv_decode(apdu->cmd, data_len, ss_proactive_get_cat_descr());
+	envelope = ss_btlv_decode(apdu->cmd, data_len, ss_proactive_get_cat_descr());
 	if (!envelope) {
-		SS_LOGP(SPROACT, LERROR,
-			"failed to decode BER-TLV encoded envelope\n");
+		SS_LOGP(SPROACT, LERROR, "failed to decode BER-TLV encoded envelope\n");
 		return SS_SW_ERR_WRONG_PARAM_INCORRECT_DATA;
 	}
 	ss_btlv_dump(envelope, 2, SPROACT, LDEBUG);
@@ -136,17 +129,11 @@ int ss_uicc_cat_cmd_envelope(struct ss_apdu *apdu)
 	rc = SS_SW_ERR_WRONG_PARAM_FUNCTION_NOT_SUPPORTED;
 	for (i = 0; i < SS_ARRAY_SIZE(cat_envelope_commands); i++) {
 		cat_template =
-		    ss_btlv_get_ie_minlen(envelope,
-					  cat_envelope_commands[i].iei,
-					  cat_envelope_commands[i].minlen);
+			ss_btlv_get_ie_minlen(envelope, cat_envelope_commands[i].iei, cat_envelope_commands[i].minlen);
 		if (cat_template) {
-			SS_LOGP(SPROACT, LDEBUG,
-				"executing handler function for CAT TEMPLATE %02x: %s\n",
-				cat_envelope_commands[i].iei,
-				cat_envelope_commands[i].name);
-			rc = cat_envelope_commands[i].handler(apdu,
-							      cat_template->
-							      value);
+			SS_LOGP(SPROACT, LDEBUG, "executing handler function for CAT TEMPLATE %02x: %s\n",
+				cat_envelope_commands[i].iei, cat_envelope_commands[i].name);
+			rc = cat_envelope_commands[i].handler(apdu, cat_template->value);
 		}
 	}
 
@@ -165,8 +152,7 @@ int ss_uicc_cat_cmd_fetch(struct ss_apdu *apdu)
 		goto leave;
 	}
 
-	memcpy(apdu->rsp, apdu->ctx->proactive.data,
-	       apdu->ctx->proactive.data_len);
+	memcpy(apdu->rsp, apdu->ctx->proactive.data, apdu->ctx->proactive.data_len);
 	apdu->rsp_len = apdu->ctx->proactive.data_len;
 
 leave:
@@ -182,7 +168,6 @@ int ss_uicc_cat_cmd_term_resp(struct ss_apdu *apdu)
 {
 	if (!apdu->ctx->proactive.enabled)
 		return SS_SW_ERR_WRONG_PARAM_FUNCTION_NOT_SUPPORTED;
-
 
 	term_resp_cb callback = apdu->ctx->proactive.term_resp_cb;
 	ss_proactive_reset(apdu->ctx);

--- a/src/softsim/uicc/uicc_lchan.c
+++ b/src/softsim/uicc/uicc_lchan.c
@@ -37,16 +37,12 @@ void ss_uicc_lchan_dump(const struct ss_lchan *lchan)
 			SS_LOGP(SLCHAN, LDEBUG, " pin %u verifed\n", i);
 	}
 
-	SS_LOGP(SLCHAN, LDEBUG, " selected file: %s\n",
-		ss_fs_utils_dump_path(&lchan->fs_path));
+	SS_LOGP(SLCHAN, LDEBUG, " selected file: %s\n", ss_fs_utils_dump_path(&lchan->fs_path));
 	active_adf = ss_get_file_from_path(&lchan->adf_path);
 	if (active_adf)
 		active_adf_name = ss_fcp_get_df_name(active_adf->fcp_decoded);
-	SS_LOGP(SLCHAN, LDEBUG, " active ADF: %s - %s\n",
-		ss_fs_utils_dump_path(&lchan->adf_path),
-		active_adf_name ? ss_hexdump(active_adf_name->data,
-					     active_adf_name->len) :
-		"(no AID)");
+	SS_LOGP(SLCHAN, LDEBUG, " active ADF: %s - %s\n", ss_fs_utils_dump_path(&lchan->adf_path),
+		active_adf_name ? ss_hexdump(active_adf_name->data, active_adf_name->len) : "(no AID)");
 	SS_LOGP(SLCHAN, LDEBUG, " current record: %u\n", lchan->current_record);
 }
 
@@ -94,8 +90,7 @@ struct ss_lchan *ss_uicc_lchan_get(struct ss_context *ctx, uint8_t cla)
 	if (lchan_nr == 0)
 		return &ctx->lchan;
 	else {
-		SS_LOGP(SLCHAN, LERROR, "lchan %u not found (cla=%02x)\n",
-			lchan_nr, cla);
+		SS_LOGP(SLCHAN, LERROR, "lchan %u not found (cla=%02x)\n", lchan_nr, cla);
 		return NULL;
 	}
 }

--- a/src/softsim/uicc/uicc_pin.c
+++ b/src/softsim/uicc/uicc_pin.c
@@ -68,32 +68,25 @@ static struct pin_context *get_pin_context(uint16_t *sw, uint8_t pin_no)
 	ss_fs_init(&pin_context_path);
 	rc = ss_fs_select(&pin_context_path, PIN_FID);
 	if (rc < 0) {
-		SS_LOGP(SPIN, LERROR,
-			"PIN code file not selectable -- cannot load context for PIN No.:%02x!\n",
+		SS_LOGP(SPIN, LERROR, "PIN code file not selectable -- cannot load context for PIN No.:%02x!\n",
 			pin_no);
 		ss_path_reset(&pin_context_path);
 		return NULL;
 	}
 	pin_context_file = ss_get_file_from_path(&pin_context_path);
 	if (!pin_context_file) {
-		SS_LOGP(SPIN, LERROR,
-			"PIN code file not available -- cannot load context for PIN No.:%02x!\n",
-			pin_no);
+		SS_LOGP(SPIN, LERROR, "PIN code file not available -- cannot load context for PIN No.:%02x!\n", pin_no);
 		ss_path_reset(&pin_context_path);
 		return NULL;
 	}
 
 	/* Read pin context from pin code file */
-	SS_LOGP(SPIN, LINFO, "loading pin PIN code file for PIN No.:%02x...\n",
-		pin_no);
+	SS_LOGP(SPIN, LINFO, "loading pin PIN code file for PIN No.:%02x...\n", pin_no);
 	n_pins = pin_context_file->fcp_file_descr->number_of_records;
 	for (i = 0; i < n_pins; i++) {
-		pin_context_buf =
-		    ss_fs_read_file_record(&pin_context_path, i + 1);
+		pin_context_buf = ss_fs_read_file_record(&pin_context_path, i + 1);
 		if (!pin_context_buf) {
-			SS_LOGP(SPIN, LERROR,
-				"PIN code file inconsistent -- cannot read record (%u)!\n",
-				i + 1);
+			SS_LOGP(SPIN, LERROR, "PIN code file inconsistent -- cannot read record (%u)!\n", i + 1);
 			ss_path_reset(&pin_context_path);
 			return NULL;
 		}
@@ -131,7 +124,7 @@ static void pin_context_free(struct pin_context *pin)
 	if (pin == NULL)
 		return;
 
-	struct ss_buf *pin_context_buf = (struct ss_buf *)(((char*)pin) - sizeof(struct ss_buf));
+	struct ss_buf *pin_context_buf = (struct ss_buf *)(((char *)pin) - sizeof(struct ss_buf));
 	ss_buf_free(pin_context_buf);
 }
 
@@ -150,46 +143,35 @@ static int update_pin_context(const struct pin_context *pin)
 	ss_fs_init(&pin_context_path);
 	rc = ss_fs_select(&pin_context_path, PIN_FID);
 	if (rc < 0) {
-		SS_LOGP(SPIN, LERROR,
-			"PIN code file not selectable -- cannot update context for PIN No.:%02x!\n",
+		SS_LOGP(SPIN, LERROR, "PIN code file not selectable -- cannot update context for PIN No.:%02x!\n",
 			pin->pin_no);
 		ss_path_reset(&pin_context_path);
 		return -EINVAL;
 	}
 	pin_context_file = ss_get_file_from_path(&pin_context_path);
 	if (!pin_context_file) {
-		SS_LOGP(SPIN, LERROR,
-			"PIN code file not available -- cannot update context for PIN No.:%02x!\n",
+		SS_LOGP(SPIN, LERROR, "PIN code file not available -- cannot update context for PIN No.:%02x!\n",
 			pin->pin_no);
 		ss_path_reset(&pin_context_path);
 		return -EINVAL;
 	}
 
 	/* Update pin context from pin code file */
-	SS_LOGP(SPIN, LINFO,
-		"updating pin PIN code file for PIN No.:%02x...\n",
-		pin->pin_no);
+	SS_LOGP(SPIN, LINFO, "updating pin PIN code file for PIN No.:%02x...\n", pin->pin_no);
 	n_pins = pin_context_file->fcp_file_descr->number_of_records;
 	for (i = 0; i < n_pins; i++) {
-		pin_context_buf =
-		    ss_fs_read_file_record(&pin_context_path, i + 1);
+		pin_context_buf = ss_fs_read_file_record(&pin_context_path, i + 1);
 		if (!pin_context_buf) {
-			SS_LOGP(SPIN, LERROR,
-				"PIN code file inconsistent -- cannot read record (%u)!\n",
-				i + 1);
+			SS_LOGP(SPIN, LERROR, "PIN code file inconsistent -- cannot read record (%u)!\n", i + 1);
 			ss_path_reset(&pin_context_path);
 			return -EINVAL;
 		}
 
 		pin_context_ptr = (struct pin_context *)pin_context_buf->data;
 		if (pin->pin_no == pin_context_ptr->pin_no) {
-
-			rc = ss_fs_write_file_record(&pin_context_path, i + 1,
-						     (uint8_t *) pin,
-						     sizeof(*pin));
+			rc = ss_fs_write_file_record(&pin_context_path, i + 1, (uint8_t *)pin, sizeof(*pin));
 			if (rc < 0) {
-				SS_LOGP(SPIN, LERROR,
-					"PIN code file update failed -- cannot write record (%u)!\n",
+				SS_LOGP(SPIN, LERROR, "PIN code file update failed -- cannot write record (%u)!\n",
 					i + 1);
 				ss_buf_free(pin_context_buf);
 				ss_path_reset(&pin_context_path);
@@ -213,8 +195,7 @@ static int update_pin_context(const struct pin_context *pin)
 static bool check_pin_retry_counter(const struct pin_context *pin)
 {
 	if (pin->tries >= pin->max_tries) {
-		SS_LOGP(SPIN, LERROR, "PIN (%u) is blocked -- abort\n",
-			pin->pin_no);
+		SS_LOGP(SPIN, LERROR, "PIN (%u) is blocked -- abort\n", pin->pin_no);
 		return false;
 	}
 
@@ -236,11 +217,9 @@ int ss_uicc_pin_cmd_verify_pin(struct ss_apdu *apdu)
 	/* Return number of remaining tries, see also ETSI TS 102 221,
 	 * section 11.1.9.1.2 */
 	if (apdu->lc == 0) {
-		SS_LOGP(SPIN, LDEBUG,
-			"no operation, number of remaining tries (%u) requested\n",
+		SS_LOGP(SPIN, LDEBUG, "no operation, number of remaining tries (%u) requested\n",
 			(pin->max_tries - pin->tries) & 0x0f);
-		result = SS_SW_WARN_VERIFICATION_FAILED_X_REMAIN |
-		    ((pin->max_tries - pin->tries) & 0x0f);
+		result = SS_SW_WARN_VERIFICATION_FAILED_X_REMAIN | ((pin->max_tries - pin->tries) & 0x0f);
 		goto leave;
 	}
 
@@ -252,29 +231,24 @@ int ss_uicc_pin_cmd_verify_pin(struct ss_apdu *apdu)
 
 	/* PIN must not be disabled */
 	if (!pin->enabled) {
-		SS_LOGP(SPIN, LERROR,"cannot verify, PIN (%u) is disabled -- abort\n", pin->pin_no);
+		SS_LOGP(SPIN, LERROR, "cannot verify, PIN (%u) is disabled -- abort\n", pin->pin_no);
 		result = SS_SW_ERR_CMD_NOT_ALLOWED_CONDITONS_NOT_SATISFIED;
 		goto leave;
 	}
 
 	/* Check length and match PIN code */
-	if (apdu->lc != sizeof(pin->pin)
-	    || memcmp(apdu->cmd, pin->pin, sizeof(pin->pin))) {
-		SS_LOGP(SPIN, LERROR,
-			"incorrect PIN (%u), VERIFY PIN failed -- abort\n",
-			pin->pin_no);
+	if (apdu->lc != sizeof(pin->pin) || memcmp(apdu->cmd, pin->pin, sizeof(pin->pin))) {
+		SS_LOGP(SPIN, LERROR, "incorrect PIN (%u), VERIFY PIN failed -- abort\n", pin->pin_no);
 		pin->tries++;
 		rc = update_pin_context(pin);
 		if (rc < 0)
 			result = SS_SW_ERR_CMD_NOT_ALLOWED_PIN_BLOCKED;
 		else
-			result = SS_SW_WARN_VERIFICATION_FAILED_X_REMAIN |
-		    ((pin->max_tries - pin->tries) & 0x0f);
+			result = SS_SW_WARN_VERIFICATION_FAILED_X_REMAIN | ((pin->max_tries - pin->tries) & 0x0f);
 		goto leave;
 	}
 
-	SS_LOGP(SPIN, LINFO, "valid PIN (%u), VERIFY PIN successful\n",
-		pin->pin_no);
+	SS_LOGP(SPIN, LINFO, "valid PIN (%u), VERIFY PIN successful\n", pin->pin_no);
 	apdu->lchan->pin_verfied[pin->pin_no] = true;
 	pin->tries = 0;
 	rc = update_pin_context(pin);
@@ -308,24 +282,20 @@ int ss_uicc_pin_cmd_change_pin(struct ss_apdu *apdu)
 
 	/* PIN must not be disabled */
 	if (!pin->enabled) {
-		SS_LOGP(SPIN, LERROR,"cannot change, PIN (%u) is disabled -- abort\n", pin->pin_no);
+		SS_LOGP(SPIN, LERROR, "cannot change, PIN (%u) is disabled -- abort\n", pin->pin_no);
 		result = SS_SW_ERR_CMD_NOT_ALLOWED_CONDITONS_NOT_SATISFIED;
 		goto leave;
 	}
 
 	/* Check length and match old PIN code */
-	if (apdu->lc != sizeof(pin->pin) * 2
-	    || memcmp(apdu->cmd, pin->pin, sizeof(pin->pin))) {
-		SS_LOGP(SPIN, LERROR,
-			"incorrect old PIN (%u), CHANGE PIN failed -- abort\n",
-			pin->pin_no);
+	if (apdu->lc != sizeof(pin->pin) * 2 || memcmp(apdu->cmd, pin->pin, sizeof(pin->pin))) {
+		SS_LOGP(SPIN, LERROR, "incorrect old PIN (%u), CHANGE PIN failed -- abort\n", pin->pin_no);
 		pin->tries++;
 		rc = update_pin_context(pin);
 		if (rc < 0)
 			result = SS_SW_ERR_CMD_NOT_ALLOWED_PIN_BLOCKED;
 		else
-			result =SS_SW_WARN_VERIFICATION_FAILED_X_REMAIN |
-		    ((pin->max_tries - pin->tries) & 0x0f);
+			result = SS_SW_WARN_VERIFICATION_FAILED_X_REMAIN | ((pin->max_tries - pin->tries) & 0x0f);
 		goto leave;
 	}
 
@@ -337,8 +307,7 @@ int ss_uicc_pin_cmd_change_pin(struct ss_apdu *apdu)
 		goto leave;
 	}
 
-	SS_LOGP(SPIN, LINFO, "valid PIN (%u), CHANGE PIN successful\n",
-		pin->pin_no);
+	SS_LOGP(SPIN, LINFO, "valid PIN (%u), CHANGE PIN successful\n", pin->pin_no);
 
 	result = 0;
 
@@ -369,23 +338,18 @@ int ss_uicc_pin_cmd_disable_pin(struct ss_apdu *apdu)
 	}
 
 	/* Check length and match PIN code */
-	if (apdu->lc != sizeof(pin->pin)
-	    || memcmp(apdu->cmd, pin->pin, sizeof(pin->pin))) {
-		SS_LOGP(SPIN, LERROR,
-			"incorrect PIN (%u), DISABLE PIN failed -- abort\n",
-			pin->pin_no);
+	if (apdu->lc != sizeof(pin->pin) || memcmp(apdu->cmd, pin->pin, sizeof(pin->pin))) {
+		SS_LOGP(SPIN, LERROR, "incorrect PIN (%u), DISABLE PIN failed -- abort\n", pin->pin_no);
 		pin->tries++;
 		rc = update_pin_context(pin);
 		if (rc < 0)
 			result = SS_SW_ERR_CMD_NOT_ALLOWED_PIN_BLOCKED;
 		else
-			result =SS_SW_WARN_VERIFICATION_FAILED_X_REMAIN |
-		    ((pin->max_tries - pin->tries) & 0x0f);
+			result = SS_SW_WARN_VERIFICATION_FAILED_X_REMAIN | ((pin->max_tries - pin->tries) & 0x0f);
 		goto leave;
 	}
 
-	SS_LOGP(SPIN, LINFO, "valid PIN (%u), DISABLE PIN successful\n",
-		pin->pin_no);
+	SS_LOGP(SPIN, LINFO, "valid PIN (%u), DISABLE PIN successful\n", pin->pin_no);
 	pin->tries = 0;
 	pin->enabled = false;
 	rc = update_pin_context(pin);
@@ -421,23 +385,18 @@ int ss_uicc_pin_cmd_enable_pin(struct ss_apdu *apdu)
 	}
 
 	/* Check length and match PIN code */
-	if (apdu->lc != sizeof(pin->pin)
-	    || memcmp(apdu->cmd, pin->pin, sizeof(pin->pin))) {
-		SS_LOGP(SPIN, LERROR,
-			"incorrect PIN (%u), ENABLE PIN failed -- abort\n",
-			pin->pin_no);
+	if (apdu->lc != sizeof(pin->pin) || memcmp(apdu->cmd, pin->pin, sizeof(pin->pin))) {
+		SS_LOGP(SPIN, LERROR, "incorrect PIN (%u), ENABLE PIN failed -- abort\n", pin->pin_no);
 		pin->tries++;
 		rc = update_pin_context(pin);
 		if (rc < 0)
 			result = SS_SW_ERR_CMD_NOT_ALLOWED_PIN_BLOCKED;
 		else
-			result = SS_SW_WARN_VERIFICATION_FAILED_X_REMAIN |
-		    ((pin->max_tries - pin->tries) & 0x0f);
+			result = SS_SW_WARN_VERIFICATION_FAILED_X_REMAIN | ((pin->max_tries - pin->tries) & 0x0f);
 		goto leave;
 	}
 
-	SS_LOGP(SPIN, LINFO, "valid PIN (%u), ENABLE PIN successful\n",
-		pin->pin_no);
+	SS_LOGP(SPIN, LINFO, "valid PIN (%u), ENABLE PIN successful\n", pin->pin_no);
 	pin->tries = 0;
 	pin->enabled = true;
 	rc = update_pin_context(pin);
@@ -466,35 +425,30 @@ int ss_uicc_pin_cmd_unblock_pin(struct ss_apdu *apdu)
 	/* Return number of remaining tries, see also ETSI TS 102 221,
 	 * section 11.1.13.1.2 */
 	if (apdu->lc == 0) {
-		SS_LOGP(SPIN, LDEBUG,
-			"no operation, number of remaining tries (%u) requested\n",
+		SS_LOGP(SPIN, LDEBUG, "no operation, number of remaining tries (%u) requested\n",
 			(pin->max_unblock_tries - pin->unblock_tries) & 0x0f);
 		result = SS_SW_WARN_VERIFICATION_FAILED_X_REMAIN |
-		    ((pin->max_unblock_tries - pin->unblock_tries) & 0x0f);
+			 ((pin->max_unblock_tries - pin->unblock_tries) & 0x0f);
 		goto leave;
 	}
 
 	/* PUK must not be blocked, check retry counter */
 	if (pin->unblock_tries >= pin->max_unblock_tries) {
-		SS_LOGP(SPIN, LERROR, "PUK (%u) is blocked -- abort\n",
-			pin->pin_no);
+		SS_LOGP(SPIN, LERROR, "PUK (%u) is blocked -- abort\n", pin->pin_no);
 		result = SS_SW_ERR_CMD_NOT_ALLOWED_PIN_BLOCKED;
 		goto leave;
 	}
 
 	/* Check length and match PUK code */
-	if (apdu->lc != sizeof(pin->puk) + sizeof(pin->pin)
-	    || memcmp(apdu->cmd, pin->puk, sizeof(pin->puk))) {
-		SS_LOGP(SPIN, LERROR,
-			"incorrect PUK (%u), UNBLOCK PIN failed -- abort\n",
-			pin->pin_no);
+	if (apdu->lc != sizeof(pin->puk) + sizeof(pin->pin) || memcmp(apdu->cmd, pin->puk, sizeof(pin->puk))) {
+		SS_LOGP(SPIN, LERROR, "incorrect PUK (%u), UNBLOCK PIN failed -- abort\n", pin->pin_no);
 		pin->unblock_tries++;
 		rc = update_pin_context(pin);
 		if (rc < 0)
 			result = SS_SW_ERR_CMD_NOT_ALLOWED_PIN_BLOCKED;
 		else
 			result = SS_SW_WARN_VERIFICATION_FAILED_X_REMAIN |
-		    ((pin->max_unblock_tries - pin->unblock_tries) & 0x0f);
+				 ((pin->max_unblock_tries - pin->unblock_tries) & 0x0f);
 		goto leave;
 	}
 
@@ -506,8 +460,7 @@ int ss_uicc_pin_cmd_unblock_pin(struct ss_apdu *apdu)
 	if (rc < 0) {
 		result = SS_SW_ERR_CMD_NOT_ALLOWED_PIN_BLOCKED;
 	} else {
-		SS_LOGP(SPIN, LINFO, "valid PUK (%u), UNBLOCK PIN successful\n",
-			pin->pin_no);
+		SS_LOGP(SPIN, LINFO, "valid PUK (%u), UNBLOCK PIN successful\n", pin->pin_no);
 		result = 0;
 	}
 
@@ -616,8 +569,7 @@ struct ss_buf *ss_uicc_pin_gen_pst_do(void)
 
 	rc = ss_uicc_pin_update_pst_do(pin_stat_templ);
 	if (rc < 0) {
-		SS_LOGP(SPIN, LERROR,
-			"pin status template has been generated but it was not possible to update it!\n");
+		SS_LOGP(SPIN, LERROR, "pin status template has been generated but it was not possible to update it!\n");
 	}
 	return pin_stat_templ;
 }

--- a/src/softsim/uicc/uicc_refresh.c
+++ b/src/softsim/uicc/uicc_refresh.c
@@ -22,8 +22,7 @@
 /* See also ETSI TS 102 223, section 8.6 */
 #define CMD_QUALIFIER 0x01
 
-static void term_response_cb(struct ss_context *ctx, uint8_t *resp_data,
-			     uint8_t resp_data_len)
+static void term_response_cb(struct ss_context *ctx, uint8_t *resp_data, uint8_t resp_data_len)
 {
 	struct ss_uicc_refresh_state *state = &ctx->proactive.refresh_state;
 	int rc;
@@ -31,28 +30,24 @@ static void term_response_cb(struct ss_context *ctx, uint8_t *resp_data,
 	rc = ss_proactive_get_rc(resp_data, resp_data_len, SREFRESH);
 
 	if (rc != 0 && state->retry_counter < MAX_REFRESH_RETRYS) {
-		SS_LOGP(SREFRESH, LERROR,
-			"unsccessful REFRESH command, retrying...\n");
+		SS_LOGP(SREFRESH, LERROR, "unsccessful REFRESH command, retrying...\n");
 		/* Unfortunately there is not much that can be done at this point other
 		 * than trying again. */
 		state->state = SS_REFRESH_PENDING;
 		state->retry_counter++;
 	} else if (rc != 0) {
-		SS_LOGP(SREFRESH, LERROR,
-			"unsccessful REFRESH command, giving up...\n");
+		SS_LOGP(SREFRESH, LERROR, "unsccessful REFRESH command, giving up...\n");
 		state->state = SS_REFRESH_READY;
 		state->retry_counter = 0;
 	} else {
-		SS_LOGP(SREFRESH, LDEBUG,
-			"successful REFRESH command, done!\n");
+		SS_LOGP(SREFRESH, LDEBUG, "successful REFRESH command, done!\n");
 		state->state = SS_REFRESH_READY;
 		state->retry_counter = 0;
 	}
 }
 
 /* Generate REFRESH command from the data in the state and send it */
-static int send_refresh(struct ss_context *ctx,
-			struct ss_uicc_refresh_state *state)
+static int send_refresh(struct ss_context *ctx, struct ss_uicc_refresh_state *state)
 {
 	struct ss_list *cmd_list;
 	struct ss_buf *cmd;
@@ -64,25 +59,20 @@ static int send_refresh(struct ss_context *ctx,
 	/* Generate command */
 	filelist_len = ss_fs_chg_len(state->filelist);
 	if (filelist_len < 0) {
-		SS_LOGP(SREFRESH, LDEBUG,
-			"Sending REFRESH command failed -- file list is invalid!\n");
+		SS_LOGP(SREFRESH, LDEBUG, "Sending REFRESH command failed -- file list is invalid!\n");
 		return -EINVAL;
 	}
 	cmd_list = SS_ALLOC(struct ss_list);
 	ss_list_init(cmd_list);
-	ss_ctlv_new_ie(cmd_list, TS_101_220_IEI_CMD_DETAILS, true,
-		       sizeof(cmd_details), cmd_details);
-	ss_ctlv_new_ie(cmd_list, TS_101_220_IEI_DEV_ID, true, sizeof(device_id),
-		       device_id);
-	ss_ctlv_new_ie(cmd_list, TS_101_220_IEI_FILE_LST_OR_CAT_SERV_LST, true,
-		       filelist_len, state->filelist);
+	ss_ctlv_new_ie(cmd_list, TS_101_220_IEI_CMD_DETAILS, true, sizeof(cmd_details), cmd_details);
+	ss_ctlv_new_ie(cmd_list, TS_101_220_IEI_DEV_ID, true, sizeof(device_id), device_id);
+	ss_ctlv_new_ie(cmd_list, TS_101_220_IEI_FILE_LST_OR_CAT_SERV_LST, true, filelist_len, state->filelist);
 	SS_LOGP(SREFRESH, LDEBUG, "resulting message IEs:\n");
 
 	ss_ctlv_dump(cmd_list, 2, SREFRESH, LDEBUG);
 	cmd = ss_ctlv_encode_to_ss_buf(cmd_list);
 	if (!cmd) {
-		SS_LOGP(SREFRESH, LERROR,
-			"Sending REFRESH failed -- cannot encode command!:\n");
+		SS_LOGP(SREFRESH, LERROR, "Sending REFRESH failed -- cannot encode command!:\n");
 		ss_ctlv_free(cmd_list);
 		return -EINVAL;
 	}
@@ -103,8 +93,7 @@ void ss_uicc_refresh_poll(struct ss_context *ctx)
 
 	/* Check REFRESH support, see also ETSI TS 131 111 section 5.2  */
 	if (!ss_proactive_term_prof_bit(ctx, 3, 8)) {
-		SS_LOGP(SREFRESH, LERROR,
-			"cannot refresh files, TERMINAL PROFILE does not support REFRESH command!\n");
+		SS_LOGP(SREFRESH, LERROR, "cannot refresh files, TERMINAL PROFILE does not support REFRESH command!\n");
 		rc = -EINVAL;
 		return;
 	}
@@ -112,31 +101,26 @@ void ss_uicc_refresh_poll(struct ss_context *ctx)
 	switch (state->state) {
 	case SS_REFRESH_READY:
 		if (ctx->fs_chg_filelist[0] == 0x00) {
-			SS_LOGP(SREFRESH, LDEBUG,
-				"no file changes detected, skipping...\n");
+			SS_LOGP(SREFRESH, LDEBUG, "no file changes detected, skipping...\n");
 			return;
 		}
-		SS_LOGP(SREFRESH, LDEBUG,
-			"following file changes will be refreshed:\n");
+		SS_LOGP(SREFRESH, LDEBUG, "following file changes will be refreshed:\n");
 		ss_fs_chg_dump(ctx->fs_chg_filelist, 2, SREFRESH, LDEBUG);
-		memcpy(state->filelist, ctx->fs_chg_filelist,
-		       SS_FS_CHG_BUF_SIZE);
+		memcpy(state->filelist, ctx->fs_chg_filelist, SS_FS_CHG_BUF_SIZE);
 		ctx->fs_chg_filelist[0] = 0;
 		state->state = SS_REFRESH_PENDING;
 		/* fallthrough */
 	case SS_REFRESH_PENDING:
 		rc = send_refresh(ctx, state);
 		if (rc == -EBUSY) {
-			SS_LOGP(SREFRESH, LERROR,
-				"cannot send REFRESH, another command is busy, retrying...\n");
+			SS_LOGP(SREFRESH, LERROR, "cannot send REFRESH, another command is busy, retrying...\n");
 			return;
 		} else if (rc < 0) {
 			/* Note: This should not happen since it would mean
 			 * that the data we give to send_refresh is garbled,
 			 * since we are generating it internally the data
 			 * should always be fine. */
-			SS_LOGP(SREFRESH, LERROR,
-				"cannot send REFRESH, data is not accepted, giving up...\n");
+			SS_LOGP(SREFRESH, LERROR, "cannot send REFRESH, data is not accepted, giving up...\n");
 			state->state = SS_REFRESH_READY;
 			return;
 		}
@@ -145,8 +129,7 @@ void ss_uicc_refresh_poll(struct ss_context *ctx)
 		/* fallthrough */
 	case SS_REFRESH_TRANSIT:
 		/* Do nothing, wait for the TERMINAL RESPONSE (see above) */
-		SS_LOGP(SREFRESH, LDEBUG,
-			"waiting until file changes are transmitted...:\n");
+		SS_LOGP(SREFRESH, LDEBUG, "waiting until file changes are transmitted...:\n");
 		break;
 	}
 }

--- a/src/softsim/uicc/utils.c
+++ b/src/softsim/uicc/utils.c
@@ -106,7 +106,7 @@ size_t ss_binary_from_hexstr(uint8_t *binary, size_t binary_len, const char *hex
 				hex_digit_bin = 0xff;
 		}
 
-		binary[binary_count] = (uint8_t) hex_digit_bin & 0xff;
+		binary[binary_count] = (uint8_t)hex_digit_bin & 0xff;
 		binary_count++;
 
 		if (binary_count >= binary_len)
@@ -121,7 +121,7 @@ size_t ss_binary_from_hexstr(uint8_t *binary, size_t binary_len, const char *hex
  *  \returns pointer to newly allocated ss_buf object. */
 struct ss_buf *ss_buf_from_hexstr(const char *hexstr)
 {
-	int bin_len = strlen(hexstr)/2;
+	int bin_len = strlen(hexstr) / 2;
 	struct ss_buf *sb = ss_buf_alloc(bin_len);
 
 	ss_binary_from_hexstr(sb->data, sb->len, hexstr);
@@ -142,8 +142,8 @@ uint32_t ss_uint32_from_array(const uint8_t *array, size_t len)
 	if (len > 4)
 		len = 4;
 
-	for(i = 0; i < len; i++) {
-		byte = array[len-i-1];
+	for (i = 0; i < len; i++) {
+		byte = array[len - i - 1];
 		rc |= (byte << i * 8);
 	}
 
@@ -163,8 +163,8 @@ uint64_t ss_uint64_from_array(const uint8_t *array, size_t len)
 	if (len > 8)
 		len = 8;
 
-	for(i = 0; i < len; i++) {
-		byte = array[len-i-1];
+	for (i = 0; i < len; i++) {
+		byte = array[len - i - 1];
 		rc |= (byte << i * 8);
 	}
 
@@ -226,14 +226,10 @@ size_t ss_optimal_len_for_uint32(uint32_t in)
  *  \returns converted value as uint64_t. */
 uint64_t ss_uint64_load_from_be(const uint8_t *storage)
 {
-	return ((uint64_t)storage[0] << (7 * 8)) |
-		((uint64_t)storage[1] << (6 * 8)) |
-		((uint64_t)storage[2] << (5 * 8)) |
-		((uint64_t)storage[3] << (4 * 8)) |
-		((uint64_t)storage[4] << (3 * 8)) |
-		((uint64_t)storage[5] << (2 * 8)) |
-		((uint64_t)storage[6] << (1 * 8)) |
-		((uint64_t)storage[7] << (0 * 8));
+	return ((uint64_t)storage[0] << (7 * 8)) | ((uint64_t)storage[1] << (6 * 8)) |
+	       ((uint64_t)storage[2] << (5 * 8)) | ((uint64_t)storage[3] << (4 * 8)) |
+	       ((uint64_t)storage[4] << (3 * 8)) | ((uint64_t)storage[5] << (2 * 8)) |
+	       ((uint64_t)storage[6] << (1 * 8)) | ((uint64_t)storage[7] << (0 * 8));
 }
 
 /*! Store an uint64_t value to a storage location (8 bytes, BE).

--- a/src/softsim/uicc/utils_3des.c
+++ b/src/softsim/uicc/utils_3des.c
@@ -27,8 +27,7 @@ void setup_key(const uint8_t *src, struct des3_key_s *dest)
  *  \param[inout] buffer user provided memory with plaintext to decrypt.
  *  \param[in] buffer_len length of the plaintext data to decrypt (multiple of 8).
  *  \param[in] key 16 byte DES key. */
-void ss_utils_3des_decrypt(uint8_t *buffer, size_t buffer_len,
-			   const uint8_t *key)
+void ss_utils_3des_decrypt(uint8_t *buffer, size_t buffer_len, const uint8_t *key)
 {
 	struct des3_key_s configured_key;
 	setup_key(key, &configured_key);
@@ -55,13 +54,12 @@ void ss_utils_3des_decrypt(uint8_t *buffer, size_t buffer_len,
  *  \param[inout] buffer user provided memory with plaintext to encrypt.
  *  \param[in] buffer_len length of the plaintext data to encrypt (multiple of 8).
  *  \param[in] key 16 byte DES key. */
-void ss_utils_3des_encrypt(uint8_t *buffer, size_t buffer_len,
-			   const uint8_t *key)
+void ss_utils_3des_encrypt(uint8_t *buffer, size_t buffer_len, const uint8_t *key)
 {
 	struct des3_key_s configured_key;
 	setup_key(key, &configured_key);
 
-	uint8_t cbc[DES_BLOCKSIZE] = { 0 };	/* The IV */
+	uint8_t cbc[DES_BLOCKSIZE] = { 0 }; /* The IV */
 
 	/* Adjusted from hostap's crypto_internal-cipher.c */
 	for (int i = 0; i < buffer_len / DES_BLOCKSIZE; i++) {
@@ -90,8 +88,7 @@ void ss_utils_3des_cc_setup(struct utils_3des_cc_ctx *cc, const uint8_t *key)
  *  \param[inout] cc user provided memory with checksum context.
  *  \param[in] data_len length of data slice (must be multiple of 8).
  *  \param[in] data user provided memory with data slice. */
-void ss_utils_3des_cc_feed(struct utils_3des_cc_ctx *cc, const uint8_t *data,
-			   size_t data_len)
+void ss_utils_3des_cc_feed(struct utils_3des_cc_ctx *cc, const uint8_t *data, size_t data_len)
 {
 	/*! Calculation of the cryptographic checksum (CC) using 3DES.
 	 *

--- a/src/softsim/uicc/utils_aes.c
+++ b/src/softsim/uicc/utils_aes.c
@@ -19,8 +19,7 @@
  *  \param[in] buffer_len length of the plaintext data to decrypt (multiple of 16).
  *  \param[in] key AES key.
  *  \param[in] key_len length of the AES key. */
-void ss_utils_aes_decrypt(uint8_t *buffer, size_t buffer_len,
-			  const uint8_t *key, size_t key_len)
+void ss_utils_aes_decrypt(uint8_t *buffer, size_t buffer_len, const uint8_t *key, size_t key_len)
 {
 	void *aes_ctx;
 	uint8_t cbc[AES_BLOCKSIZE] = { 0 }; /* IV, all zero */
@@ -50,8 +49,7 @@ void ss_utils_aes_decrypt(uint8_t *buffer, size_t buffer_len,
  *  \param[in] buffer_len length of the plaintext data to encrypt (multiple of 16).
  *  \param[in] key 16 byte AES key.
  *  \param[in] key_len length of the AES key. */
-void ss_utils_aes_encrypt(uint8_t *buffer, size_t buffer_len,
-			   const uint8_t *key, size_t key_len)
+void ss_utils_aes_encrypt(uint8_t *buffer, size_t buffer_len, const uint8_t *key, size_t key_len)
 {
 	void *aes_ctx;
 	uint8_t cbc[AES_BLOCKSIZE] = { 0 }; /* IV, all zero */
@@ -80,9 +78,9 @@ static void leftshift_onebit(uint8_t *input, uint8_t *output)
 	uint8_t carry = 0;
 
 	for (i = AES_BLOCKSIZE; i > 0; i--) {
-		output[i-1] = input[i-1] << 1;
-		output[i-1] |= carry;
-		carry = (input[i-1] & 0x80) ? 1 : 0;
+		output[i - 1] = input[i - 1] << 1;
+		output[i - 1] |= carry;
+		carry = (input[i - 1] & 0x80) ? 1 : 0;
 	}
 	return;
 }
@@ -100,8 +98,7 @@ static void xor_128(uint8_t *a, uint8_t *b, uint8_t *out)
  *  \param[in] key AES key.
  *  \param[in] key_len length of the  AES key.
  *  \param[in] inert_padding apply padding without chaning crypto process. */
-void ss_utils_aes_cc_setup(struct utils_aes_cc_ctx *cc, const uint8_t *key,
-			   size_t key_len, bool inert_padding)
+void ss_utils_aes_cc_setup(struct utils_aes_cc_ctx *cc, const uint8_t *key, size_t key_len, bool inert_padding)
 {
 	/*! Note: The AES-CMAC algorithm specifies a separate path in case the
 	 *  input data has to be padded. The option "inert_padding" will handle
@@ -113,10 +110,8 @@ void ss_utils_aes_cc_setup(struct utils_aes_cc_ctx *cc, const uint8_t *key,
 	uint8_t L[AES_BLOCKSIZE] = { 0 };
 	uint8_t tmp[AES_BLOCKSIZE];
 
-	uint8_t const_Rb[] = {
-		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x87
-	};
+	uint8_t const_Rb[] = { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+			       0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x87 };
 
 	memset(cc, 0, sizeof(*cc));
 	cc->aes_ctx = aes_encrypt_init(key, key_len);
@@ -143,8 +138,7 @@ void ss_utils_aes_cc_setup(struct utils_aes_cc_ctx *cc, const uint8_t *key,
  *  \param[in] data_len length of data slice (must be multiple of 16).
  *  \param[in] data user provided memory with data slice.
  *  \param[in] last set to true when feeding the last block. */
-void ss_utils_aes_cc_feed(struct utils_aes_cc_ctx *cc, const uint8_t *data,
-			  size_t data_len, bool last)
+void ss_utils_aes_cc_feed(struct utils_aes_cc_ctx *cc, const uint8_t *data, size_t data_len, bool last)
 {
 	/*! Calculation of the cryptographic checksum (CC) using AES.
 	 *  (See also see also RFC 4493, section 2.2 and utils_3des.c */

--- a/src/softsim/uicc/utils_ota.c
+++ b/src/softsim/uicc/utils_ota.c
@@ -32,7 +32,7 @@ uint8_t ss_utils_ota_calc_pcnt(enum enc_algorithm algorithm, size_t data_len)
 	default:
 		blocksize = 1; /* No padding */
 	}
-	
+
 	return (-(blocksize + data_len)) % blocksize;
 }
 
@@ -46,10 +46,8 @@ uint8_t ss_utils_ota_calc_pcnt(enum enc_algorithm algorithm, size_t data_len)
  *  \param[in] data2 user buffer containing part 2 of the data.
  *  \param[in] data2_len length of data part 2 (unpadded).
  *  \returns 0 on success, -EINVAL on error. */
-int ss_utils_ota_calc_cc(uint8_t *cc, size_t cc_len,
-			 uint8_t *key, size_t key_len, enum enc_algorithm alg,
-			 uint8_t *data1, size_t data1_len,
-			 uint8_t *data2, size_t data2_len)
+int ss_utils_ota_calc_cc(uint8_t *cc, size_t cc_len, uint8_t *key, size_t key_len, enum enc_algorithm alg,
+			 uint8_t *data1, size_t data1_len, uint8_t *data2, size_t data2_len)
 {
 	struct utils_3des_cc_ctx cc_des;
 	struct utils_aes_cc_ctx cc_aes;
@@ -87,8 +85,7 @@ int ss_utils_ota_calc_cc(uint8_t *cc, size_t cc_len,
 		memcpy(cc, cc_aes.cbc, cc_len);
 		return 0;
 	default:
-		SS_LOGP(SREMOTECMD, LERROR,
-			"unable to calculate cc, improper crypto algorithm selected\n");
+		SS_LOGP(SREMOTECMD, LERROR, "unable to calculate cc, improper crypto algorithm selected\n");
 		return -EINVAL;
 	}
 }


### PR DESCRIPTION
Introducing clang-format to this open source repository to make collaboration both easier and prettier in the future. 

* chore: 🤖 add a standard .clang-format

* chore: 🤖 use clang-format for src/softsim/uicc/*

* chore: sortincludes ironically not sorted

* chore: disable clang-format for log.c