### PR TITLE
fix: properly initialize argument 'fdset' of select()

### DIFF
--- a/src/softsim/main.c
+++ b/src/softsim/main.c
@@ -238,14 +238,14 @@ int main(void)
 
 	SS_LOGP(SVPCD, LINFO, "connected.\n");
 
-	FD_ZERO(&fdset);
-	FD_SET(socket_fd, &fdset);
-
 	select_timeout.tv_sec = 0;
 	select_timeout.tv_usec = 500000;
 
 	while (running) {
 		select_timer = select_timeout;
+
+		FD_ZERO(&fdset);
+		FD_SET(socket_fd, &fdset);
 
 		rc = select(socket_fd + 1, &fdset, NULL, NULL, &select_timer);
 		if (rc < 0)


### PR DESCRIPTION
Argument 'fdset' of select() may have been modified after a call to select() (for example if there is a timeout, select() will return an empty 'fdset'). Let's initialize it before each call to select().