### PR TITLE
refactor: clean up the profile decoder

### DIFF
--- a/utils/ss_profile.c
+++ b/utils/ss_profile.c
@@ -41,81 +41,69 @@ uint8_t ss_profile_from_string(uint16_t len, const char input_string[len], struc
 		pos = data_end;
 
 		// bad encoding
-		if (data_end > len) {
+		if (data_end > len)
 			return 1;
-		}
 
 		switch (tag) {
 		case IMSI_TAG:
-			if (!(data_len == IMSI_LEN)) {
+			if (data_len != IMSI_LEN)
 				return 10;
-			}
 			memcpy(&profile->_3F00_7ff0_6f07, &input_string[data_start], data_len);
 			break;
 		case ICCID_TAG:
-			if (!(data_len == ICCID_LEN)) {
+			if (data_len != ICCID_LEN)
 				return 11;
-			}
 			memcpy(&profile->_3F00_2FE2, &input_string[data_start], data_len);
 			break;
 		case OPC_TAG:
-			if (!(data_len == KEY_SIZE)) {
+			if (data_len != KEY_SIZE)
 				return 12;
-			}
 			memcpy(&profile->_3F00_A001[KEY_SIZE], &input_string[data_start], data_len);
 			break;
 		case KI_TAG:
-			if (!(data_len == KEY_SIZE)) {
+			if (data_len != KEY_SIZE)
 				return 13;
-			}
 			memcpy(&profile->_3F00_A001[0], &input_string[data_start], data_len);
 			ss_hex_string_to_bytes(&input_string[data_start], data_len, profile->k);
 			break;
 		case KIC_TAG:
-			if (!(data_len == KEY_SIZE)) {
+			if (data_len != KEY_SIZE)
 				return 14;
-			}
 			memcpy(&profile->_3F00_A004[A004_HEADER_SIZE], &input_string[data_start], data_len);
 			ss_hex_string_to_bytes(&input_string[data_start], data_len, profile->kic);
 			break;
 		case KID_TAG:
-			if (!(data_len == KEY_SIZE)) {
+			if (data_len != KEY_SIZE)
 				return 15;
-			}
 			memcpy(&profile->_3F00_A004[A004_HEADER_SIZE + KEY_SIZE], &input_string[data_start], data_len);
 			ss_hex_string_to_bytes(&input_string[data_start], data_len, profile->kid);
 			break;
 		case SMSP_TAG:
-			if (!(data_len == SMSP_RECORD_SIZE)) {
+			if (data_len != SMSP_RECORD_SIZE)
 				return 16;
-			}
 			memcpy(&profile->SMSP, &input_string[data_start], data_len);
 			break;
 		case PIN_1_TAG:
-			if (!(data_len <= PIN_SIZE)) {
+			if (data_len > PIN_SIZE)
 				break;
-			}
 			memcpy(&profile->_3F00_A003[0 * A003_RECORD_SIZE + PIN_OFFSET], &input_string[data_start],
 			       data_len);
 			break;
 		case PIN_2_TAG:
-			if (!(data_len <= PIN_SIZE)) {
+			if (data_len > PIN_SIZE)
 				break;
-			}
 			memcpy(&profile->_3F00_A003[1 * A003_RECORD_SIZE + PIN_OFFSET], &input_string[data_start],
 			       data_len);
 			break;
 		case PIN_ADM_TAG:
-			if (!(data_len <= PIN_SIZE)) {
+			if (data_len > PIN_SIZE)
 				break;
-			}
 			memcpy(&profile->_3F00_A003[2 * A003_RECORD_SIZE + PIN_OFFSET], &input_string[data_start],
 			       data_len);
 			break;
 		case PUK_TAG:
-			if (!(data_len <= PIN_SIZE)) {
+			if (data_len > PIN_SIZE)
 				break;
-			}
 			memcpy(&profile->_3F00_A003[0 * A003_RECORD_SIZE + PUK_OFFSET], &input_string[data_start],
 			       data_len);
 			memcpy(&profile->_3F00_A003[1 * A003_RECORD_SIZE + PUK_OFFSET], &input_string[data_start],


### PR DESCRIPTION
This pull request simplifies conditional checks in the ss_profile_from_string function within utils/ss_profile.c. The changes improve code readability by removing unnecessary parentheses and negations in conditional expressions.