### PR TITLE
fix: get proper value for ss_dirs_len

### DIFF
--- a/utils/files-c-array/ss_static_files_bin.c
+++ b/utils/files-c-array/ss_static_files_bin.c
@@ -202,6 +202,6 @@ const ss_file_t ss_files_arr[] = {
 {.name = "/3f00/a1df1d01.def", .data = _3f00_a1df1d01_def, .size = sizeof(_3f00_a1df1d01_def)}
 };
 const uint32_t ss_files_len = 98;
-const uint32_t ss_dirs_len = 3;
+const uint32_t ss_dirs_len = 2;
 const ss_file_t *ss_files = ss_files_arr;
 const ss_dir_t *ss_dirs = ss_dirs_arr;

--- a/utils/files-c-array/ss_static_files_hex.c
+++ b/utils/files-c-array/ss_static_files_hex.c
@@ -202,6 +202,6 @@ const ss_file_t ss_files_arr[] = {
 {.name = "/3f00/a1df1d01.def", .data = _3f00_a1df1d01_def, .size = 38}
 };
 const uint32_t ss_files_len = 98;
-const uint32_t ss_dirs_len = 3;
+const uint32_t ss_dirs_len = 2;
 const ss_file_t *ss_files = ss_files_arr;
 const ss_dir_t *ss_dirs = ss_dirs_arr;

--- a/utils/files-c-array/toCArray.py
+++ b/utils/files-c-array/toCArray.py
@@ -14,8 +14,6 @@ def to_c_array(path='files', out_path='ss_static_files.c', mode='bin'):
     s += 'const ss_dir_t ss_dirs_arr[] = {\n'
     ds = []
     for d in directories:
-        if d == '':
-            continue
         ds.append( f'{{.name = "{d}"}}')
     s += ', \n'.join(ds) + '\n};\n'
 
@@ -60,7 +58,8 @@ def get_dirs_and_files(path):
 
     for root, d_names, f_names in os.walk(path):
         current_dir = root.split('files')[-1]
-        directories.append(current_dir)
+        if current_dir:
+            directories.append(current_dir)
         for file in f_names:
             files.append(current_dir+'/'+file)
 


### PR DESCRIPTION
'' is put in 'directories', leading to computing the wrong length of the array later on. Don't include '' in 'directories' to avoid this problem.

Also remove the test "if d == '':" which becomes irrelevant.

And regenerate files with this new code.