### PR TITLE
fix: support Case 1 APDUs and STATUS Le handling for nRF91 modem

### DIFF
--- a/src/softsim/uicc/softsim.c
+++ b/src/softsim/uicc/softsim.c
@@ -411,7 +411,9 @@ size_t ss_transact(struct ss_context *ctx, uint8_t *response_buf, size_t respons
 
 	/* A valid APDU must have a length of at least 5 bytes, any shorter
 	 * APDU counts as invalid and must not be processed any further. */
-	if (_request_len < 5) {
+	/* Allow 4-byte Case 1 APDUs (header only: CLA INS P1 P2)
+	 * The parser ss_apdu_parse_exhaustive supports this format */
+	if (_request_len < 4) {
 		SS_LOGP(SIFACE, LERROR, "ignoring short APDU: %s\n", ss_hexdump(request_buf, _request_len));
 		response_buf[response_len++] = SS_SW_ERR_CHECKING_WRONG_LENGTH >> 8;
 		response_buf[response_len++] = SS_SW_ERR_CHECKING_WRONG_LENGTH & 0xff;
@@ -496,7 +498,9 @@ size_t ss_application_apdu_transact(struct ss_context *ctx, uint8_t *response_bu
 	size_t _request_len = *request_len;
 	uint16_t le = 0;
 
-	if (_request_len < 5) {
+	/* Allow 4-byte Case 1 APDUs (header only: CLA INS P1 P2)
+	 * The parser ss_apdu_parse_exhaustive supports this format */
+	if (_request_len < 4) {
 		SS_LOGP(SIFACE, LERROR, "ignoring short APDU: %s\n", ss_hexdump(request_buf, _request_len));
 		response_buf[response_len++] = SS_SW_ERR_CHECKING_WRONG_LENGTH >> 8;
 		response_buf[response_len++] = SS_SW_ERR_CHECKING_WRONG_LENGTH & 0xff;

--- a/tests/init/init_test.ok
+++ b/tests/init/init_test.ok
@@ -13,13 +13,13 @@
 >>> Card APDU request 00a4040410a0000000871002ffffffff8907090000 >>>
 <<< Card APDU response 62308202782183027ff08410a0000000871002ffffffff89070900008a01058b032f060fc60c90012083010183018183010a9000 <<<
 >>> Card APDU request 00200001 >>>
-<<< Card APDU response 6700 <<<
+<<< Card APDU response 63c3 <<<
 >>> Card APDU request 002c0001 >>>
-<<< Card APDU response 6700 <<<
+<<< Card APDU response 63ca <<<
 >>> Card APDU request 00200081 >>>
-<<< Card APDU response 6700 <<<
+<<< Card APDU response 63c3 <<<
 >>> Card APDU request 002c0081 >>>
-<<< Card APDU response 6700 <<<
+<<< Card APDU response 63ca <<<
 >>> Card APDU request 00a40804022f0e00 >>>
 <<< Card APDU response 6a82 <<<
 >>> Card APDU request 00a40804047fff6f0500 >>>
@@ -49,7 +49,7 @@
 >>> Card APDU request 00a40804047fff6f7b00 >>>
 <<< Card APDU response 62178202412183026f7b8a01058b036f06048002000c8801689000 <<<
 >>> Card APDU request 80f2010c >>>
-<<< Card APDU response 6700 <<<
+<<< Card APDU response 9000 <<<
 >>> Card APDU request 00a40804047fff6fe800 >>>
 <<< Card APDU response 6a82 <<<
 >>> Card APDU request 80f2000032 >>>


### PR DESCRIPTION
This change addresses a real-world APDU variant observed on Nordic nRF91 modems: the modem may issue Case 1
 APDUs that are only 4 bytes (`CLA INS P1 P2`, i.e., no `Lc`/`Le`), notably for STATUS. The
 previous "minimum APDU length = 5" guard would therefore reject valid traffic before parsing.

In addition, the nRF91 modem is reported to not reliably recover from an SW `6Cxx` (“wrong expected length; resend with xx”), so relying on that retry path can break STATUS exchanges even when the implementation is otherwise correct.

## What this PR changes

**Accept 4-byte APDUs (Case 1) at the interface layer**
   A command APDU has a mandatory 4-byte header and an optional body; Case 1 specifically has an empty body (no `Lc` and no `Le`).  
   This PR aligns the “short APDU” guard with that reality by accepting 4-byte APDUs and letting the existing parser handle them.