### PR TITLE
refactor: correct format string warnings for size_t and uint64_t types

### DIFF
--- a/include/onomondo/softsim/fs.h
+++ b/include/onomondo/softsim/fs.h
@@ -10,7 +10,7 @@ ss_FILE ss_fopen(char *path, char *mode) __attribute__((weak));
 int ss_fclose(ss_FILE) __attribute__((weak));
 size_t ss_fread(void *ptr, size_t size, size_t nmemb, ss_FILE fp) __attribute__((weak));
 size_t ss_fwrite(const void *prt, size_t size, size_t count, ss_FILE f) __attribute__((weak));
-int ss_file_size(char *path) __attribute__((weak));
+int ss_file_size(const char *path) __attribute__((weak));
 int ss_delete_file(const char *path) __attribute__((weak));
 int ss_delete_dir(const char *path) __attribute__((weak));
 int ss_fseek(ss_FILE fp, long offset, int whence) __attribute__((weak));

--- a/src/softsim/fs.c
+++ b/src/softsim/fs.c
@@ -56,7 +56,7 @@ size_t ss_fwrite(const void *prt, size_t size, size_t count, ss_FILE f)
 	return fwrite(prt, size, count, (FILE *)f);
 }
 
-int ss_file_size(char *path)
+int ss_file_size(const char *path)
 {
 	int rc;
 	FILE *f;

--- a/src/softsim/storage.c
+++ b/src/softsim/storage.c
@@ -164,7 +164,7 @@ struct ss_buf *ss_storage_read_file(const struct ss_list *path, size_t read_offs
 
 	rc = ss_fseek(fd, read_offset * 2, SEEK_SET);
 	if (rc != 0) {
-		SS_LOGP(SSTORAGE, LERROR, "unable to seek (read_offset=%lu) requested data in content file: %s\n",
+		SS_LOGP(SSTORAGE, LERROR, "unable to seek (read_offset=%zu) requested data in content file: %s\n",
 			read_offset, host_path);
 		SS_FREE(line_buf);
 		ss_fclose(fd);
@@ -173,7 +173,7 @@ struct ss_buf *ss_storage_read_file(const struct ss_list *path, size_t read_offs
 
 	fgets_rc = ss_fread(line_buf, 2, read_len, fd);
 	if (fgets_rc != read_len) {
-		SS_LOGP(SSTORAGE, LERROR, "unable to load content (read_offset=%lu, read_len=%lu) from file: %s\n",
+		SS_LOGP(SSTORAGE, LERROR, "unable to load content (read_offset=%zu, read_len=%zu) from file: %s\n",
 			read_offset, read_len, host_path);
 		SS_FREE(line_buf);
 		ss_fclose(fd);
@@ -209,7 +209,7 @@ int ss_storage_write_file(const struct ss_list *path, const uint8_t *data, size_
 
 	rc = ss_fseek(fd, write_offset * 2, SEEK_SET);
 	if (rc != 0) {
-		SS_LOGP(SSTORAGE, LERROR, "unable to seek (write_offset=%lu) data to content file: %s\n", write_offset,
+		SS_LOGP(SSTORAGE, LERROR, "unable to seek (write_offset=%zu) data to content file: %s\n", write_offset,
 			host_path);
 		ss_fclose(fd);
 		return -EINVAL;
@@ -221,7 +221,7 @@ int ss_storage_write_file(const struct ss_list *path, const uint8_t *data, size_
 		snprintf(hex, sizeof(hex), "%02x", data[i]);
 		fwrite_rc = ss_fwrite(hex, sizeof(hex) - 1, 1, fd);
 		if (fwrite_rc != 1) {
-			SS_LOGP(SSTORAGE, LERROR, "unable to write (write_offset=%lu+%lu) data to content file: %s\n",
+			SS_LOGP(SSTORAGE, LERROR, "unable to write (write_offset=%zu+%zu) data to content file: %s\n",
 				write_offset, i, host_path);
 			ss_fclose(fd);
 			return -EINVAL;

--- a/src/softsim/storage.c
+++ b/src/softsim/storage.c
@@ -172,7 +172,7 @@ struct ss_buf *ss_storage_read_file(const struct ss_list *path, size_t read_offs
 
 	rc = ss_fseek(fd, read_offset * 2, SEEK_SET);
 	if (rc != 0) {
-		SS_LOGP(SSTORAGE, LERROR, "unable to seek (read_offset=%lu) requested data in content file: %s\n",
+		SS_LOGP(SSTORAGE, LERROR, "unable to seek (read_offset=%zu) requested data in content file: %s\n",
 			read_offset, host_path);
 		SS_FREE(line_buf);
 		ss_fclose(fd);
@@ -181,7 +181,7 @@ struct ss_buf *ss_storage_read_file(const struct ss_list *path, size_t read_offs
 
 	fgets_rc = ss_fread(line_buf, 2, read_len, fd);
 	if (fgets_rc != read_len) {
-		SS_LOGP(SSTORAGE, LERROR, "unable to load content (read_offset=%lu, read_len=%lu) from file: %s\n",
+		SS_LOGP(SSTORAGE, LERROR, "unable to load content (read_offset=%zu, read_len=%zu) from file: %s\n",
 			read_offset, read_len, host_path);
 		SS_FREE(line_buf);
 		ss_fclose(fd);
@@ -222,7 +222,7 @@ int ss_storage_write_file(const struct ss_list *path, const uint8_t *data, size_
 
 	rc = ss_fseek(fd, write_offset * 2, SEEK_SET);
 	if (rc != 0) {
-		SS_LOGP(SSTORAGE, LERROR, "unable to seek (write_offset=%lu) data to content file: %s\n", write_offset,
+		SS_LOGP(SSTORAGE, LERROR, "unable to seek (write_offset=%zu) data to content file: %s\n", write_offset,
 			host_path);
 		ss_fclose(fd);
 		return -EINVAL;
@@ -234,7 +234,7 @@ int ss_storage_write_file(const struct ss_list *path, const uint8_t *data, size_
 		snprintf(hex, sizeof(hex), "%02x", data[i]);
 		fwrite_rc = ss_fwrite(hex, sizeof(hex) - 1, 1, fd);
 		if (fwrite_rc != 1) {
-			SS_LOGP(SSTORAGE, LERROR, "unable to write (write_offset=%lu+%lu) data to content file: %s\n",
+			SS_LOGP(SSTORAGE, LERROR, "unable to write (write_offset=%zu+%zu) data to content file: %s\n",
 				write_offset, i, host_path);
 			ss_fclose(fd);
 			return -EINVAL;

--- a/src/softsim/uicc/btlv_enc.c
+++ b/src/softsim/uicc/btlv_enc.c
@@ -201,7 +201,7 @@ size_t ss_btlv_encode(uint8_t *enc, size_t len, struct ss_list *list)
 	 * enough memory for the result */
 	if (len < bytes_needed) {
 		SS_LOGP(SBTLV, LDEBUG,
-			"cannot encode BER-TLV string, buffer to small (bytes needed: %lu, bytes available: %lu\n",
+			"cannot encode BER-TLV string, buffer to small (bytes needed: %zu, bytes available: %zu\n",
 			bytes_needed, len);
 		return 0;
 	}

--- a/src/softsim/uicc/df_name.c
+++ b/src/softsim/uicc/df_name.c
@@ -53,7 +53,7 @@ int ss_df_name_update(struct ss_list *path)
 	}
 
 	if (fcp_df_name_ie->value->len > 16) {
-		SS_LOGP(SDFNAME, LERROR, "cannot register too long DF_NAME %s, len=%lu > 16\n",
+		SS_LOGP(SDFNAME, LERROR, "cannot register too long DF_NAME %s, len=%zu > 16\n",
 			ss_hexdump(fcp_df_name_ie->value->data, fcp_df_name_ie->value->len),
 			fcp_df_name_ie->value->len);
 		return -EINVAL;
@@ -113,7 +113,7 @@ int ss_df_name_update(struct ss_list *path)
 		goto leave;
 	}
 
-	SS_LOGP(SDFNAME, LDEBUG, "registered DF_NAME=%s for FID=%02x%02x in file %s on record number %lu\n",
+	SS_LOGP(SDFNAME, LDEBUG, "registered DF_NAME=%s for FID=%02x%02x in file %s on record number %zu\n",
 		ss_hexdump(fcp_df_name_ie->value->data, fcp_df_name_ie->value->len), fcp_fid_ie->value->data[0],
 		fcp_fid_ie->value->data[1], ss_fs_utils_dump_path(&path_copy), free_record);
 	rc = 0;
@@ -183,7 +183,7 @@ int ss_df_name_resolve(struct ss_list *path, const uint8_t *df_name, size_t df_n
 	record = ss_fs_read_file_record(&path_copy, record_number);
 	if (!record) {
 		SS_LOGP(SDFNAME, LERROR,
-			"unable to resolve DF_NAME=%s to FID - lookup file %s is not readable at record number %lu\n",
+			"unable to resolve DF_NAME=%s to FID - lookup file %s is not readable at record number %zu\n",
 			ss_hexdump(df_name, df_name_len), ss_fs_utils_dump_path(&path_copy), record_number);
 		rc = -EINVAL;
 		goto leave;

--- a/src/softsim/uicc/fs.c
+++ b/src/softsim/uicc/fs.c
@@ -247,12 +247,12 @@ struct ss_buf *ss_fs_read_file_record(const struct ss_list *path, size_t record_
 	 * has to maintain this state and then call this function with the
 	 * absolue record number. */
 	if (record_no == 0) {
-		SS_LOGP(SFS, LINFO, "non existing record (%lu) referenced in file (%04x)\n", record_no, file->fid);
+		SS_LOGP(SFS, LINFO, "non existing record (%zu) referenced in file (%04x)\n", record_no, file->fid);
 		return NULL;
 	}
 
 	if (record_no > file->fcp_file_descr->number_of_records + 1) {
-		SS_LOGP(SFS, LINFO, "non existing record (%lu) referenced in file (%04x)\n", record_no, file->fid);
+		SS_LOGP(SFS, LINFO, "non existing record (%zu) referenced in file (%04x)\n", record_no, file->fid);
 		return NULL;
 	}
 
@@ -282,12 +282,12 @@ int ss_fs_write_file_record(const struct ss_list *path, size_t record_no, const 
 
 	/* See also note in ss_fs_get_file_record() */
 	if (record_no == 0) {
-		SS_LOGP(SFS, LINFO, "non existing record (%lu) referenced in file (%04x)\n", record_no, file->fid);
+		SS_LOGP(SFS, LINFO, "non existing record (%zu) referenced in file (%04x)\n", record_no, file->fid);
 		return -EINVAL;
 	}
 
 	if (record_no > file->fcp_file_descr->number_of_records + 1) {
-		SS_LOGP(SFS, LINFO, "non existing record (%lu) referenced in file (%04x), file has %u records\n",
+		SS_LOGP(SFS, LINFO, "non existing record (%zu) referenced in file (%04x), file has %u records\n",
 			record_no, file->fid, file->fcp_file_descr->number_of_records);
 		return -EINVAL;
 	}
@@ -299,7 +299,7 @@ int ss_fs_write_file_record(const struct ss_list *path, size_t record_no, const 
 	}
 
 	if (file->fcp_file_descr->record_len != len) {
-		SS_LOGP(SFS, LINFO, "cannot write record with improper length (%u != %lu) to file (%04x)\n",
+		SS_LOGP(SFS, LINFO, "cannot write record with improper length (%u != %zu) to file (%04x)\n",
 			file->fcp_file_descr->record_len, len, file->fid);
 		return -EINVAL;
 	}

--- a/src/softsim/uicc/fs_utils.c
+++ b/src/softsim/uicc/fs_utils.c
@@ -61,7 +61,7 @@ size_t ss_fs_utils_find_free_record(const struct ss_list *path)
 	for (i = 0; i < file->fcp_file_descr->number_of_records; i++) {
 		record = ss_fs_read_file_record(path, i + 1);
 		if (!record) {
-			SS_LOGP(SFS, LERROR, "cannot read record %lu in internal file: %s\n", i + 1,
+			SS_LOGP(SFS, LERROR, "cannot read record %zu in internal file: %s\n", i + 1,
 				ss_fs_utils_dump_path(path));
 			return 0;
 		}
@@ -111,7 +111,7 @@ size_t ss_fs_utils_find_record(const struct ss_list *path, const uint8_t *templa
 	for (i = 0; i < file->fcp_file_descr->number_of_records; i++) {
 		record = ss_fs_read_file_record(path, i + 1);
 		if (!record) {
-			SS_LOGP(SFS, LERROR, "cannot read record %lu in internal file: %s\n", i + 1,
+			SS_LOGP(SFS, LERROR, "cannot read record %zu in internal file: %s\n", i + 1,
 				ss_fs_utils_dump_path(path));
 			return 0;
 		}

--- a/src/softsim/uicc/softsim.c
+++ b/src/softsim/uicc/softsim.c
@@ -233,7 +233,7 @@ static int apdu_transact(struct ss_context *ctx, struct ss_apdu *apdu)
 			 * up the data in a second try. */
 			apdu->lchan->last_apdu_keep = true;
 			apdu->le = 0;
-			SS_LOGP(SLCHAN, LERROR, "incorrect response length requested (%u), expecting %lu\n",
+			SS_LOGP(SLCHAN, LERROR, "incorrect response length requested (%u), expecting %zu\n",
 				apdu->hdr.p3, last_apdu->rsp_len);
 		} else {
 			memcpy(apdu->rsp, last_apdu->rsp, last_apdu->rsp_len);
@@ -326,7 +326,7 @@ out:
 			SS_LOGP(SLCHAN, LDEBUG, "Returning rsp_len = %zu bytes after le = 0\n", apdu->rsp_len);
 		} else if (apdu->le != apdu->rsp_len) {
 			SS_LOGP(SLCHAN, LERROR,
-				"invalid response data, le (%u) != rsp_len (%lu), changing SW=%04x to SW=%04x (wrong length)\n",
+				"invalid response data, le (%u) != rsp_len (%zu), changing SW=%04x to SW=%04x (wrong length)\n",
 				apdu->le, apdu->rsp_len, apdu->sw, SS_SW_ERR_CHECKING_WRONG_LENGTH);
 			apdu->sw = SS_SW_ERR_CHECKING_WRONG_LENGTH;
 			apdu->rsp_len = 0;
@@ -338,7 +338,7 @@ out:
 		apdu->sw = 0x9100 | ctx->proactive.data_len;
 
 	if (apdu->rsp_len) {
-		SS_LOGP(SLCHAN, LDEBUG, "Tx R-APDU SW=%04x %s (%lu bytes)\n", apdu->sw,
+		SS_LOGP(SLCHAN, LDEBUG, "Tx R-APDU SW=%04x %s (%zu bytes)\n", apdu->sw,
 			ss_hexdump(apdu->rsp, apdu->rsp_len), apdu->rsp_len);
 	} else {
 		SS_LOGP(SLCHAN, LDEBUG, "Tx R-APDU SW=%04x\n", apdu->sw);
@@ -428,7 +428,7 @@ size_t ss_transact(struct ss_context *ctx, uint8_t *response_buf, size_t respons
 	 * of the request is not yet known and the APDUs come in a concatenated
 	 * list without delimiters or length information. */
 	if (_request_len > sizeof(apdu->cmd) + sizeof(apdu->hdr)) {
-		SS_LOGP(SIFACE, LINFO, "request exceeds maximum length %lu > %lu, will truncate.\n", _request_len,
+		SS_LOGP(SIFACE, LINFO, "request exceeds maximum length %zu > %zu, will truncate.\n", _request_len,
 			sizeof(apdu->cmd) + sizeof(apdu->hdr));
 		_request_len = sizeof(apdu->cmd) + sizeof(apdu->hdr);
 	}

--- a/src/softsim/uicc/softsim.c
+++ b/src/softsim/uicc/softsim.c
@@ -234,7 +234,7 @@ static int apdu_transact(struct ss_context *ctx, struct ss_apdu *apdu)
 			 * up the data in a second try. */
 			apdu->lchan->last_apdu_keep = true;
 			apdu->le = 0;
-			SS_LOGP(SLCHAN, LERROR, "incorrect response length requested (%u), expecting %lu\n",
+			SS_LOGP(SLCHAN, LERROR, "incorrect response length requested (%u), expecting %zu\n",
 				apdu->hdr.p3, last_apdu->rsp_len);
 		} else {
 			memcpy(apdu->rsp, last_apdu->rsp, last_apdu->rsp_len);
@@ -345,7 +345,7 @@ out:
 			SS_LOGP(SLCHAN, LDEBUG, "Returning rsp_len = %zu bytes after le = 0\n", apdu->rsp_len);
 		} else if (apdu->rsp_len > apdu->le) {
 			SS_LOGP(SLCHAN, LERROR,
-				"invalid response data, rsp_len (%lu) > le (%u), changing SW=%04x to SW=%04x (wrong length)\n",
+				"invalid response data, rsp_len (%zu) > le (%u), changing SW=%04x to SW=%04x (wrong length)\n",
 				apdu->rsp_len, apdu->le, apdu->sw, SS_SW_ERR_CHECKING_WRONG_LENGTH);
 			apdu->sw = SS_SW_ERR_CHECKING_WRONG_LENGTH;
 			apdu->rsp_len = 0;
@@ -357,7 +357,7 @@ out:
 		apdu->sw = 0x9100 | ctx->proactive.data_len;
 
 	if (apdu->rsp_len) {
-		SS_LOGP(SLCHAN, LDEBUG, "Tx R-APDU SW=%04x %s (%lu bytes)\n", apdu->sw,
+		SS_LOGP(SLCHAN, LDEBUG, "Tx R-APDU SW=%04x %s (%zu bytes)\n", apdu->sw,
 			ss_hexdump(apdu->rsp, apdu->rsp_len), apdu->rsp_len);
 	} else {
 		SS_LOGP(SLCHAN, LDEBUG, "Tx R-APDU SW=%04x\n", apdu->sw);
@@ -449,7 +449,7 @@ size_t ss_transact(struct ss_context *ctx, uint8_t *response_buf, size_t respons
 	 * of the request is not yet known and the APDUs come in a concatenated
 	 * list without delimiters or length information. */
 	if (_request_len > sizeof(apdu->cmd) + sizeof(apdu->hdr)) {
-		SS_LOGP(SIFACE, LINFO, "request exceeds maximum length %lu > %lu, will truncate.\n", _request_len,
+		SS_LOGP(SIFACE, LINFO, "request exceeds maximum length %zu > %zu, will truncate.\n", _request_len,
 			sizeof(apdu->cmd) + sizeof(apdu->hdr));
 		_request_len = sizeof(apdu->cmd) + sizeof(apdu->hdr);
 	}


### PR DESCRIPTION
Fix compiler warnings about format specifier mismatches:

- Use %zu instead of %lu for size_t variables in:
  * btlv_enc.c - bytes_needed, len parameters
  * df_name.c - DF_NAME length, record numbers
  * fs.c - record_no, len parameters
  * fs_utils.c - record iteration index
  * softsim.c - rsp_len, request_len
  * storage.c - read/write offsets
  * uicc_remote_cmd.c - written_length, commands_len

- Use PRIu64/PRIx64 from <inttypes.h> for uint64_t variables in:
  * uicc_remote_cmd.c - CNTR counter values

- Change ss_file_size() signature from char* to const char*
  * fs.h - consistent with other path functions in the API