### PR TITLE
fix: the cryptographic extension function at ss_cryp... in...

### DIFF
--- a/utils/ss_crypto_extension.c
+++ b/utils/ss_crypto_extension.c
@@ -12,6 +12,8 @@
 
 void ss_load_key_external(const uint8_t *key_id, size_t in_len, uint8_t *key, size_t *key_len)
 {
+	if (in_len > *key_len)
+		in_len = *key_len;
 	memcpy(key, key_id, in_len);
 	*key_len = in_len;
 }


### PR DESCRIPTION
## Summary
Fix critical severity security issue in `utils/ss_crypto_extension.c`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-002 |
| **Severity** | CRITICAL |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-002` |
| **File** | `utils/ss_crypto_extension.c:15` |

**Description**: The cryptographic extension function at ss_crypto_extension.c:15 copies in_len bytes from the key_id input into a fixed-size key buffer using memcpy without first verifying that in_len does not exceed the allocated size of the key buffer. An attacker who can supply a crafted in_len value larger than the key buffer through a malformed APDU command or provisioning message can overwrite adjacent heap memory, including cryptographic key material and heap metadata.

## Changes
- `utils/ss_crypto_extension.c`

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
