### PR TITLE
fix: correct address extension bit decoding for SMS

### DIFF
--- a/src/softsim/uicc/sms.c
+++ b/src/softsim/uicc/sms.c
@@ -57,8 +57,8 @@ static int decode_addr(struct ss_sms_addr *addr_dec, const uint8_t *addr, size_t
 	addr++;
 
 	/* Decode header */
-	addr_dec->extension = (*addr && 0x80);
-	addr_dec->type_of_number = *addr >> 4 & 0x07;
+	addr_dec->extension = (*addr & 0x80) != 0;
+	addr_dec->type_of_number = (*addr >> 4) & 0x07;
 	addr_dec->numbering_plan = *addr & 0x0F;
 	addr++;
 


### PR DESCRIPTION
Replaces the logical AND (&&) with a bitwise AND (&) to correctly
extract the extension bit from the address byte. ETSI TS 23.040 §9.1.2.5 Address Fields

Also adds clarifying parentheses to the Type-of-Number (TON)
expression. C precedence already evaluates "*addr >> 4 & 0x07" as
"(*addr >> 4) & 0x07" — this is a readability improvement, not a
behavioral fix.