### PR TITLE
fix: support concatenated sms pp data download

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,6 +61,10 @@ if(CONFIG_ENABLE_SANITIZE)
 	add_link_options(-fsanitize=address -fsanitize=undefined)
 endif()
 
+if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME AND BUILD_TESTING)
+	add_compile_definitions(CONFIG_USE_SYSTEM_HEAP)
+endif()
+
 add_subdirectory(src)
 
 set(install_target_collection
@@ -91,7 +95,6 @@ install(TARGETS ${install_target_collection}
 )
 
 if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME AND BUILD_TESTING)
-	add_compile_definitions(CONFIG_USE_SYSTEM_HEAP)
 	include(CTest)
 	add_subdirectory(tests)
 endif()

--- a/src/softsim/uicc/uicc_cat.c
+++ b/src/softsim/uicc/uicc_cat.c
@@ -66,7 +66,7 @@ int handle_sms_pp_dwnld(struct ss_apdu *apdu, struct ss_buf *cat_template)
 
 leave:
 	ss_ctlv_free(ctlv_data);
-	return 0;
+	return rc;
 }
 
 const struct ss_cat_envelope_command cat_envelope_commands[] = {

--- a/src/softsim/uicc/uicc_remote_cmd.c
+++ b/src/softsim/uicc/uicc_remote_cmd.c
@@ -151,7 +151,7 @@ static int parse_cmd_hdr_clrtxt(struct command_parameters *param, size_t cmd_pac
 		SS_LOGP(SREMOTECMD, LERROR, "Received comand packet too short\n");
 		/* Is there any better guidance? This is only based on general ISO 7816
 		 * ENVELOPE descriptions. */
-		return SS_SW_ERR_CHECKING_WRONG_LENGTH;
+		return -SS_SW_ERR_CHECKING_WRONG_LENGTH;
 	}
 
 	SS_LOGP(SREMOTECMD, LDEBUG, "command packet header data (cleartext): %s\n", ss_hexdump(cmd_packet, 10));

--- a/src/softsim/uicc/uicc_sms_rx.c
+++ b/src/softsim/uicc/uicc_sms_rx.c
@@ -27,26 +27,79 @@
  * V5.9.0 Seciton 6.2 */
 #define IEI_CPI 0x70
 
-static void clear_state(struct ss_uicc_sms_rx_state *state)
+#define SMS_RX_MAX_REASSEMBLIES 4
+#define SMS_RX_MAX_REASSEMBLED_LEN (SMS_MAX_SIZE * 255)
+
+struct ss_uicc_sms_rx_sm {
+	struct ss_list list;
+	uint8_t msg_part_no;
+	uint8_t tp_ud[SMS_MAX_SIZE];
+	size_t tp_ud_len;
+};
+
+struct ss_uicc_sms_rx_reassembly {
+	struct ss_list list;
+	struct ss_list sm;
+	struct ss_sms_addr tp_oa;
+	uint8_t tp_pid;
+	uint8_t tp_dcs;
+	bool concat_ref_16bit;
+	uint16_t concat_ref;
+	uint8_t msg_parts;
+	uint8_t msg_parts_received;
+	size_t tp_ud_len;
+	bool ud_hdr_set;
+	uint8_t ud_hdr[SMS_MAX_SIZE];
+	size_t ud_hdr_len;
+};
+
+struct sms_rx_udh_info {
+	bool concat_present;
+	bool concat_ref_16bit;
+	uint16_t concat_ref;
+	uint8_t msg_parts;
+	uint8_t msg_part_no;
+	uint8_t ud_hdr[SMS_MAX_SIZE];
+	size_t ud_hdr_len;
+};
+
+static void init_state_if_needed(struct ss_uicc_sms_rx_state *state)
+{
+	if (!ss_list_initialized(&state->reassemblies))
+		ss_list_init(&state->reassemblies);
+}
+
+static void free_reassembly(struct ss_uicc_sms_rx_reassembly *reassembly)
 {
 	struct ss_uicc_sms_rx_sm *sm;
 	struct ss_uicc_sms_rx_sm *sm_pre;
 
-	/* When the number of message parts is set to zero, there is no
-	 * multi part SMS reception in progress, wich means we can simply
-	 * wipe of all state with zeros. There will be no SMS message in
-	 * the list that could leak memory. */
-	if (state->msg_parts == 0)
-		goto leave;
-
-	SS_LIST_FOR_EACH_SAVE(&state->sm, sm, sm_pre, struct ss_uicc_sms_rx_sm, list) {
-		ss_list_remove(&sm->list);
-		SS_FREE(sm);
+	if (ss_list_initialized(&reassembly->sm)) {
+		SS_LIST_FOR_EACH_SAVE(&reassembly->sm, sm, sm_pre, struct ss_uicc_sms_rx_sm, list) {
+			ss_list_remove(&sm->list);
+			SS_FREE(sm);
+		}
 	}
 
-leave:
+	memset(reassembly, 0, sizeof(*reassembly));
+	SS_FREE(reassembly);
+}
+
+static void clear_state(struct ss_uicc_sms_rx_state *state)
+{
+	struct ss_uicc_sms_rx_reassembly *reassembly;
+	struct ss_uicc_sms_rx_reassembly *reassembly_pre;
+
+	if (ss_list_initialized(&state->reassemblies)) {
+		SS_LIST_FOR_EACH_SAVE(&state->reassemblies, reassembly, reassembly_pre,
+				      struct ss_uicc_sms_rx_reassembly, list) {
+			ss_list_remove(&reassembly->list);
+			free_reassembly(reassembly);
+		}
+	}
+
 	memset(state, 0, sizeof(*state));
-	ss_list_init(&state->sm);
+	ss_list_init(&state->reassemblies);
 }
 
 /*! Clear CAT SMS state, needs to be executed once on startup.
@@ -57,11 +110,42 @@ void ss_uicc_sms_rx_clear(struct ss_context *ctx)
 	clear_state(state);
 }
 
-/* Get an SM part we have received before from the SM list. */
-static struct ss_uicc_sms_rx_sm *get_sm_part(struct ss_uicc_sms_rx_state *state, uint8_t msg_part_no)
+static bool sms_addr_equal(const struct ss_sms_addr *a, const struct ss_sms_addr *b)
+{
+	return a->extension == b->extension && a->type_of_number == b->type_of_number &&
+	       a->numbering_plan == b->numbering_plan && strcmp(a->digits, b->digits) == 0;
+}
+
+static bool reassembly_matches(const struct ss_uicc_sms_rx_reassembly *reassembly, const struct ss_sm_hdr *sm_hdr,
+			       const struct sms_rx_udh_info *udh_info)
+{
+	const struct ss_sms_deliver *sms_deliver = &sm_hdr->u.sms_deliver;
+
+	return sms_addr_equal(&reassembly->tp_oa, &sms_deliver->tp_oa) &&
+	       reassembly->tp_pid == sms_deliver->tp_pid && reassembly->tp_dcs == sms_deliver->tp_dcs &&
+	       reassembly->concat_ref_16bit == udh_info->concat_ref_16bit &&
+	       reassembly->concat_ref == udh_info->concat_ref && reassembly->msg_parts == udh_info->msg_parts;
+}
+
+static struct ss_uicc_sms_rx_reassembly *find_reassembly(struct ss_uicc_sms_rx_state *state,
+							 const struct ss_sm_hdr *sm_hdr,
+							 const struct sms_rx_udh_info *udh_info)
+{
+	struct ss_uicc_sms_rx_reassembly *reassembly;
+
+	init_state_if_needed(state);
+	SS_LIST_FOR_EACH(&state->reassemblies, reassembly, struct ss_uicc_sms_rx_reassembly, list) {
+		if (reassembly_matches(reassembly, sm_hdr, udh_info))
+			return reassembly;
+	}
+
+	return NULL;
+}
+
+static struct ss_uicc_sms_rx_sm *get_sm_part(struct ss_uicc_sms_rx_reassembly *reassembly, uint8_t msg_part_no)
 {
 	struct ss_uicc_sms_rx_sm *sm;
-	SS_LIST_FOR_EACH(&state->sm, sm, struct ss_uicc_sms_rx_sm, list) {
+	SS_LIST_FOR_EACH(&reassembly->sm, sm, struct ss_uicc_sms_rx_sm, list) {
 		if (sm->msg_part_no == msg_part_no)
 			return sm;
 	}
@@ -69,118 +153,242 @@ static struct ss_uicc_sms_rx_sm *get_sm_part(struct ss_uicc_sms_rx_state *state,
 	return NULL;
 }
 
-/* Put an SM part into SM list for later processing. */
-static int put_sm_part(struct ss_uicc_sms_rx_state *state, struct ss_uicc_sms_rx_sm *sm)
+static void remove_reassembly(struct ss_uicc_sms_rx_state *state, struct ss_uicc_sms_rx_reassembly *reassembly)
 {
-	struct ss_uicc_sms_rx_sm *sm_i;
+	ss_list_remove(&reassembly->list);
+	assert(state->reassembly_count > 0);
+	state->reassembly_count--;
+	free_reassembly(reassembly);
+}
 
-	/* Ignore duplicates */
-	SS_LIST_FOR_EACH(&state->sm, sm_i, struct ss_uicc_sms_rx_sm, list) {
-		if (sm_i->msg_part_no == sm->msg_part_no) {
-			SS_LOGP(SSMS, LERROR, "ignoring duplicate part %u/%u of message %u\n", sm->msg_part_no,
-				state->msg_parts, sm->msg_id);
-			return -EINVAL;
+static void evict_oldest_reassembly(struct ss_uicc_sms_rx_state *state)
+{
+	struct ss_uicc_sms_rx_reassembly *reassembly;
+
+	if (ss_list_empty(&state->reassemblies))
+		return;
+
+	reassembly = SS_LIST_GET(state->reassemblies.next, struct ss_uicc_sms_rx_reassembly, list);
+	SS_LOGP(SSMS, LERROR, "evicting incomplete concatenated SM ref=%u (%u-bit), received %u/%u parts\n",
+		reassembly->concat_ref, reassembly->concat_ref_16bit ? 16 : 8, reassembly->msg_parts_received,
+		reassembly->msg_parts);
+	remove_reassembly(state, reassembly);
+}
+
+static struct ss_uicc_sms_rx_reassembly *new_reassembly(struct ss_uicc_sms_rx_state *state,
+							const struct ss_sm_hdr *sm_hdr,
+							const struct sms_rx_udh_info *udh_info)
+{
+	struct ss_uicc_sms_rx_reassembly *reassembly;
+	const struct ss_sms_deliver *sms_deliver = &sm_hdr->u.sms_deliver;
+
+	init_state_if_needed(state);
+	if (state->reassembly_count >= SMS_RX_MAX_REASSEMBLIES)
+		evict_oldest_reassembly(state);
+
+	reassembly = SS_ALLOC(struct ss_uicc_sms_rx_reassembly);
+	if (!reassembly)
+		return NULL;
+
+	memset(reassembly, 0, sizeof(*reassembly));
+	ss_list_init(&reassembly->sm);
+	memcpy(&reassembly->tp_oa, &sms_deliver->tp_oa, sizeof(reassembly->tp_oa));
+	reassembly->tp_pid = sms_deliver->tp_pid;
+	reassembly->tp_dcs = sms_deliver->tp_dcs;
+	reassembly->concat_ref_16bit = udh_info->concat_ref_16bit;
+	reassembly->concat_ref = udh_info->concat_ref;
+	reassembly->msg_parts = udh_info->msg_parts;
+
+	ss_list_put(&state->reassemblies, &reassembly->list);
+	state->reassembly_count++;
+
+	return reassembly;
+}
+
+static int parse_ud_hdr(struct sms_rx_udh_info *udh_info, const uint8_t *ud_hdr, size_t ud_hdr_len)
+{
+	size_t pos = 0;
+
+	memset(udh_info, 0, sizeof(*udh_info));
+	while (pos < ud_hdr_len) {
+		uint8_t iei;
+		uint8_t ie_len;
+		const uint8_t *ie_value;
+
+		if (ud_hdr_len - pos < 2) {
+			SS_LOGP(SSMS, LERROR, "failed to decode user data header, truncated IE header\n");
+			return SS_SW_ERR_WRONG_PARAM_INCORRECT_DATA;
 		}
+
+		iei = ud_hdr[pos];
+		ie_len = ud_hdr[pos + 1];
+		if (ie_len > ud_hdr_len - pos - 2) {
+			SS_LOGP(SSMS, LERROR, "failed to decode user data header, IE length exceeds UDHL\n");
+			return SS_SW_ERR_WRONG_PARAM_INCORRECT_DATA;
+		}
+		ie_value = &ud_hdr[pos + 2];
+
+		if (iei == TS_23_040_IEI_CONCAT_SMS || iei == TS_23_040_IEI_CONCAT_SMS_REF) {
+			if (udh_info->concat_present) {
+				SS_LOGP(SSMS, LERROR, "failed to decode user data header, multiple concat IEs\n");
+				return SS_SW_ERR_WRONG_PARAM_INCORRECT_DATA;
+			}
+			if (iei == TS_23_040_IEI_CONCAT_SMS) {
+				if (ie_len != 3) {
+					SS_LOGP(SSMS, LERROR,
+						"failed to decode 8-bit concat IE, expected len=3, got %u\n",
+						ie_len);
+					return SS_SW_ERR_WRONG_PARAM_INCORRECT_DATA;
+				}
+				udh_info->concat_ref_16bit = false;
+				udh_info->concat_ref = ie_value[0];
+				udh_info->msg_parts = ie_value[1];
+				udh_info->msg_part_no = ie_value[2];
+			} else {
+				if (ie_len != 4) {
+					SS_LOGP(SSMS, LERROR,
+						"failed to decode 16-bit concat IE, expected len=4, got %u\n",
+						ie_len);
+					return SS_SW_ERR_WRONG_PARAM_INCORRECT_DATA;
+				}
+				udh_info->concat_ref_16bit = true;
+				udh_info->concat_ref = ((uint16_t)ie_value[0] << 8) | ie_value[1];
+				udh_info->msg_parts = ie_value[2];
+				udh_info->msg_part_no = ie_value[3];
+			}
+
+			if (udh_info->msg_parts == 0 || udh_info->msg_part_no == 0 ||
+			    udh_info->msg_part_no > udh_info->msg_parts) {
+				SS_LOGP(SSMS, LERROR,
+					"invalid concat IE ref=%u (%u-bit), part=%u/%u\n",
+					udh_info->concat_ref, udh_info->concat_ref_16bit ? 16 : 8,
+					udh_info->msg_part_no, udh_info->msg_parts);
+				return SS_SW_ERR_WRONG_PARAM_INCORRECT_DATA;
+			}
+
+			udh_info->concat_present = true;
+		} else {
+			if (udh_info->ud_hdr_len + 2 + ie_len > sizeof(udh_info->ud_hdr)) {
+				SS_LOGP(SSMS, LERROR, "failed to preserve user data header, UDH too large\n");
+				return SS_SW_ERR_WRONG_PARAM_INCORRECT_DATA;
+			}
+			udh_info->ud_hdr[udh_info->ud_hdr_len++] = iei;
+			udh_info->ud_hdr[udh_info->ud_hdr_len++] = ie_len;
+			memcpy(&udh_info->ud_hdr[udh_info->ud_hdr_len], ie_value, ie_len);
+			udh_info->ud_hdr_len += ie_len;
+		}
+
+		pos += 2 + ie_len;
 	}
 
-	ss_list_put(&state->sm, &sm->list);
 	return 0;
 }
 
-/* Collect and when complete concatenate all SM parts to one large SM */
-static struct ss_buf *concat_sm(struct ss_uicc_sms_rx_state *state, uint8_t *tp_ud, size_t tp_ud_len,
-				struct tlv8_ie *concat_sm_desc_ie)
+static int decode_ud_hdr(struct ss_list **ud_hdr_dec, const uint8_t *ud_hdr, size_t ud_hdr_len)
+{
+	*ud_hdr_dec = NULL;
+	if (ud_hdr_len == 0)
+		return 0;
+
+	*ud_hdr_dec = ss_tlv8_decode(ud_hdr, ud_hdr_len);
+	if (!*ud_hdr_dec) {
+		SS_LOGP(SSMS, LERROR, "failed to decode user data header, invalid TLV data\n");
+		return SS_SW_ERR_WRONG_PARAM_INCORRECT_DATA;
+	}
+	ss_tlv8_dump(*ud_hdr_dec, 2, SSMS, LDEBUG);
+
+	return 0;
+}
+
+static int store_reassembly_ud_hdr(struct ss_uicc_sms_rx_reassembly *reassembly,
+				   const struct sms_rx_udh_info *udh_info)
+{
+	if (udh_info->ud_hdr_len == 0)
+		return 0;
+
+	if (!reassembly->ud_hdr_set) {
+		memcpy(reassembly->ud_hdr, udh_info->ud_hdr, udh_info->ud_hdr_len);
+		reassembly->ud_hdr_len = udh_info->ud_hdr_len;
+		reassembly->ud_hdr_set = true;
+		return 0;
+	}
+
+	if (reassembly->ud_hdr_len != udh_info->ud_hdr_len ||
+	    memcmp(reassembly->ud_hdr, udh_info->ud_hdr, udh_info->ud_hdr_len) != 0) {
+		SS_LOGP(SSMS, LERROR, "conflicting non-concat UDH in concatenated SM ref=%u\n",
+			reassembly->concat_ref);
+		return SS_SW_ERR_WRONG_PARAM_INCORRECT_DATA;
+	}
+
+	return 0;
+}
+
+static int put_sm_part(struct ss_uicc_sms_rx_reassembly *reassembly, uint8_t msg_part_no, const uint8_t *tp_ud,
+		       size_t tp_ud_len, bool *complete)
 {
 	struct ss_uicc_sms_rx_sm *sm;
-	uint8_t i;
-	size_t result_len = 0;
-	struct ss_buf *result = NULL;
-	uint8_t *result_ptr;
-	int rc;
-	uint8_t msg_id = concat_sm_desc_ie->value->data[0];
-	uint8_t msg_parts = concat_sm_desc_ie->value->data[1];
-	uint8_t msg_part_no = concat_sm_desc_ie->value->data[2];
 
-	SS_LOGP(SSMS, LERROR, "receiving part %u/%u of message %u: %s\n", msg_part_no, msg_parts, msg_id,
-		ss_hexdump(tp_ud, tp_ud_len));
-
-	/* Clear state when a new message is detected */
-	if (state->msg_id != msg_id) {
-		SS_LOGP(SSMS, LERROR, "message %u is a new message, clearing state.\n", msg_id);
-		clear_state(state);
-		state->msg_id = msg_id;
-		state->msg_parts = msg_parts;
-	}
-
-	/* Make sure that each message reports the same number of message
-	 * parts */
-	if (msg_parts != state->msg_parts) {
+	*complete = false;
+	if (tp_ud_len > SMS_MAX_SIZE) {
 		SS_LOGP(SSMS, LERROR,
-			"message part %u of message %u reports invalid number of message parts expected %u, got %u\n",
-			msg_part_no, msg_id, state->msg_parts, msg_parts);
-		clear_state(state);
-		return NULL;
+			"receiving part %u/%u of message ref=%u exceeds SMS TP-UD size, got %zu octets\n",
+			msg_part_no, reassembly->msg_parts, reassembly->concat_ref, tp_ud_len);
+		return SS_SW_ERR_WRONG_PARAM_INCORRECT_DATA;
 	}
 
-	/* Make sure that the message id cannot be larger than the expected number of
-	 * messages. The message id also mut not be 0 */
-	if (msg_part_no > state->msg_parts) {
-		SS_LOGP(SSMS, LERROR,
-			"message %u reports invalid message part number %u, expecting id in range 1-%u.\n", msg_id,
-			msg_part_no, state->msg_parts);
-		clear_state(state);
-		return NULL;
-	}
-
-	/* NOTE: In reality, the message cannot be longer than 140 octets,
-	 * so we won't see the following error message unless there are
-	 * serios software problems elsewhere. */
-	if (tp_ud_len > sizeof(sm->tp_ud)) {
-		SS_LOGP(SSMS, LERROR,
-			"receiving part %u/%u of message %u exceeds size of a normal SMS, expected < %zu octets, got %zu octets.\n",
-			msg_part_no, msg_parts, msg_id, sizeof(sm->tp_ud), tp_ud_len);
-		return NULL;
-	}
-
-	/* Store message in list */
-	sm = SS_ALLOC(struct ss_uicc_sms_rx_sm);
-	memcpy(sm->tp_ud, tp_ud, tp_ud_len);
-	sm->tp_ud_len = tp_ud_len;
-	sm->msg_part_no = msg_part_no;
-	sm->msg_id = msg_id;
-	rc = put_sm_part(state, sm);
-	if (rc < 0) {
-		SS_FREE(sm);
-		return NULL;
-	}
-
-	/* Check if we got the complete message */
-	for (i = 0; i < msg_parts; i++) {
-		sm = get_sm_part(state, i + 1);
-		if (!sm) {
-			SS_LOGP(SSMS, LDEBUG, "message %u is not complete yet, still waiting for message part %u/%u.\n",
-				msg_id, msg_parts, i + 1);
-			return NULL;
+	sm = get_sm_part(reassembly, msg_part_no);
+	if (sm) {
+		if (sm->tp_ud_len == tp_ud_len && memcmp(sm->tp_ud, tp_ud, tp_ud_len) == 0) {
+			SS_LOGP(SSMS, LDEBUG, "ignoring duplicate part %u/%u of message ref=%u\n",
+				msg_part_no, reassembly->msg_parts, reassembly->concat_ref);
+			return 0;
 		}
 
-		result_len += sm->tp_ud_len;
+		SS_LOGP(SSMS, LERROR, "conflicting duplicate part %u/%u of message ref=%u\n", msg_part_no,
+			reassembly->msg_parts, reassembly->concat_ref);
+		return SS_SW_ERR_WRONG_PARAM_INCORRECT_DATA;
 	}
 
-	/* Concatenate message */
-	result = ss_buf_alloc(result_len);
+	if (reassembly->tp_ud_len + tp_ud_len > SMS_RX_MAX_REASSEMBLED_LEN) {
+		SS_LOGP(SSMS, LERROR, "concatenated SM ref=%u exceeds maximum reassembled length\n",
+			reassembly->concat_ref);
+		return SS_SW_ERR_WRONG_PARAM_INCORRECT_DATA;
+	}
+
+	sm = SS_ALLOC(struct ss_uicc_sms_rx_sm);
+	if (!sm)
+		return SS_SW_ERR_WRONG_PARAM_ENOMEM;
+
+	memset(sm, 0, sizeof(*sm));
+	sm->msg_part_no = msg_part_no;
+	memcpy(sm->tp_ud, tp_ud, tp_ud_len);
+	sm->tp_ud_len = tp_ud_len;
+	ss_list_put(&reassembly->sm, &sm->list);
+	reassembly->msg_parts_received++;
+	reassembly->tp_ud_len += tp_ud_len;
+
+	*complete = reassembly->msg_parts_received == reassembly->msg_parts;
+	return 0;
+}
+
+static struct ss_buf *reassemble_sm(struct ss_uicc_sms_rx_reassembly *reassembly)
+{
+	uint8_t i;
+	uint8_t *result_ptr;
+	struct ss_buf *result;
+
+	result = ss_buf_alloc(reassembly->tp_ud_len);
 	result_ptr = result->data;
-	for (i = 0; i < msg_parts; i++) {
-		sm = get_sm_part(state, i + 1);
-		if (!sm)
-			assert(false);
-		if (sm->msg_id != msg_id)
-			assert(false);
+
+	for (i = 1; i <= reassembly->msg_parts; i++) {
+		struct ss_uicc_sms_rx_sm *sm = get_sm_part(reassembly, i);
+		assert(sm);
 		memcpy(result_ptr, sm->tp_ud, sm->tp_ud_len);
 		result_ptr += sm->tp_ud_len;
 	}
 
-	SS_LOGP(SSMS, LDEBUG, "message %u complete: %s\n", msg_id, ss_hexdump(result->data, result->len));
-	clear_state(state);
+	SS_LOGP(SSMS, LDEBUG, "message ref=%u complete: %s\n", reassembly->concat_ref,
+		ss_hexdump(result->data, result->len));
 	return result;
 }
 
@@ -189,27 +397,18 @@ static struct ss_buf *concat_sm(struct ss_uicc_sms_rx_state *state, uint8_t *tp_
  *
  * The response arguments behave like those of @ref ss_uicc_sms_rx.
  * */
-static int handle_sm(struct ss_context *ctx, struct ss_sm_hdr *sm_hdr, uint8_t *ud_hdr, size_t ud_hdr_len,
-		     uint8_t *tp_ud, size_t tp_ud_len, size_t *response_len, uint8_t response[*response_len])
+static int handle_sm(struct ss_context *ctx, struct ss_sm_hdr *sm_hdr, struct ss_list *ud_hdr_dec, uint8_t *tp_ud,
+		     size_t tp_ud_len, size_t *response_len, uint8_t response[*response_len])
 {
-	int rc;
-
+	int rc = 0;
 	assert(sm_hdr->tp_mti == SMS_MTI_DELIVER);
 
-	/* IEIa -- first information element identifier; typically 0x70 = CPI
-	 *
-	 * Left at 0 if UDHI is unset; that case can be treated like any unknown
-	 * IEIOa */
-	uint8_t ieia = 0;
-
-	if (ud_hdr_len >= 2) {
-		ieia = ud_hdr[0];
-		/* Ignoring both IEIDa (data for IE a) and any further IEs, as
-		 * none of them are used in the currently only implemented case */
+	struct tlv8_ie *cpi_ie = NULL;
+	if (ud_hdr_dec) {
+		cpi_ie = ss_tlv8_get_ie(ud_hdr_dec, IEI_CPI);
 	}
 
-	switch (ieia) {
-	case IEI_CPI:;
+	if (cpi_ie) {
 		struct ss_buf *sms_response = NULL;
 		rc = ss_uicc_remote_cmd_receive(tp_ud_len, tp_ud, response_len, response, &sms_response,
 						ctx->fs_chg_filelist);
@@ -222,30 +421,79 @@ static int handle_sm(struct ss_context *ctx, struct ss_sm_hdr *sm_hdr, uint8_t *
 			response_hdr.u.sms_submit.tp_da.extension = true;
 			memcpy(&response_hdr.u.sms_submit.tp_da, &sm_hdr->u.sms_deliver.tp_oa,
 			       sizeof(struct ss_sms_addr));
-			/* TP-Protocol-Identifier: unsure */
 			response_hdr.u.sms_submit.tp_pid = 127;
-			/* data coding scheme: 8-bit data */
 			response_hdr.u.sms_submit.tp_dcs = 246;
-			/* UDHI gets set automatically when encode_sm gets its hands on it */
 
-			ss_uicc_sms_tx(ctx, &response_hdr,
-				       /* The response is a single blob with both UDH and UD, which makes
-                * sense there as that's part of what gets integrity protected, but as
-				        * sms_tx needs to fragment it, we're dissecting the message for it */
-				       &sms_response->data[1], sms_response->data[0],
+			ss_uicc_sms_tx(ctx, &response_hdr, &sms_response->data[1], sms_response->data[0],
 				       &sms_response->data[1 + sms_response->data[0]],
-				       sms_response->len - 1 - sms_response->data[0],
-				       /* Couldn't do anything else than debug logging */
-				       NULL);
+				       sms_response->len - 1 - sms_response->data[0], NULL);
 			SS_LOGP(SSMS, LDEBUG, "Enqueued SMS in response to command\n");
 			ss_buf_free(sms_response);
 		}
-		break;
-	default:
-		SS_LOGP(SSMS, LDEBUG, "received sms TP-UD with unknown IEIa=%02x:%s\n", ieia,
+	} else {
+		SS_LOGP(SSMS, LDEBUG, "received sms TP-UD with no CPI IE (0x70) in UDH: %s\n",
 			ss_hexdump(tp_ud, tp_ud_len));
-		rc = -1;
+		*response_len = 0;
 	}
+
+	return rc;
+}
+
+static int process_concat_sm(struct ss_context *ctx, struct ss_uicc_sms_rx_state *state, struct ss_sm_hdr *sm_hdr,
+			     const struct sms_rx_udh_info *udh_info, uint8_t *tp_ud, size_t tp_ud_len,
+			     size_t *response_len, uint8_t response[*response_len])
+{
+	struct ss_uicc_sms_rx_reassembly *reassembly;
+	struct ss_buf *concat_sm_buf = NULL;
+	struct ss_list *ud_hdr_dec = NULL;
+	bool complete;
+	int rc;
+
+	reassembly = find_reassembly(state, sm_hdr, udh_info);
+	if (!reassembly) {
+		reassembly = new_reassembly(state, sm_hdr, udh_info);
+		if (!reassembly) {
+			*response_len = 0;
+			return SS_SW_ERR_WRONG_PARAM_ENOMEM;
+		}
+	}
+
+	rc = store_reassembly_ud_hdr(reassembly, udh_info);
+	if (rc != 0) {
+		remove_reassembly(state, reassembly);
+		*response_len = 0;
+		return rc;
+	}
+
+	SS_LOGP(SSMS, LDEBUG, "receiving part %u/%u of message ref=%u (%u-bit): %s\n", udh_info->msg_part_no,
+		udh_info->msg_parts, udh_info->concat_ref, udh_info->concat_ref_16bit ? 16 : 8,
+		ss_hexdump(tp_ud, tp_ud_len));
+
+	rc = put_sm_part(reassembly, udh_info->msg_part_no, tp_ud, tp_ud_len, &complete);
+	if (rc != 0) {
+		remove_reassembly(state, reassembly);
+		*response_len = 0;
+		return rc;
+	}
+
+	if (!complete) {
+		SS_LOGP(SSMS, LDEBUG, "message ref=%u is not complete yet, received %u/%u parts.\n",
+			reassembly->concat_ref, reassembly->msg_parts_received, reassembly->msg_parts);
+		*response_len = 0;
+		return 0;
+	}
+
+	concat_sm_buf = reassemble_sm(reassembly);
+	rc = decode_ud_hdr(&ud_hdr_dec, reassembly->ud_hdr, reassembly->ud_hdr_len);
+	if (rc == 0)
+		rc = handle_sm(ctx, sm_hdr, ud_hdr_dec, concat_sm_buf->data, concat_sm_buf->len, response_len, response);
+
+	if (ud_hdr_dec)
+		ss_tlv8_free(ud_hdr_dec);
+	ss_buf_free(concat_sm_buf);
+	remove_reassembly(state, reassembly);
+	if (rc != 0)
+		*response_len = 0;
 
 	return rc;
 }
@@ -269,17 +517,15 @@ int ss_uicc_sms_rx(struct ss_context *ctx, struct ss_buf *sms_tpdu, size_t *resp
 
 	uint8_t *tp_ud;
 	size_t tp_ud_len;
-
-	uint8_t *ud_hdr = NULL;
-	size_t ud_hdr_len = 0;
-
+	struct sms_rx_udh_info udh_info;
 	struct ss_list *ud_hdr_dec = NULL;
-	struct tlv8_ie *concat_sm_desc_ie = NULL;
-	struct ss_buf *concat_sm_buf;
 
+	init_state_if_needed(state);
+	memset(&udh_info, 0, sizeof(udh_info));
 	sm_hdr_len = ss_sms_hdr_decode(&sm_hdr, sms_tpdu->data, sms_tpdu->len);
 	if (sm_hdr_len < 0) {
 		SS_LOGP(SSMS, LERROR, "failed to decode SMS TPDU header.\n");
+		rc = SS_SW_ERR_WRONG_PARAM_INCORRECT_DATA;
 		*response_len = 0;
 		goto leave;
 	}
@@ -290,52 +536,46 @@ int ss_uicc_sms_rx(struct ss_context *ctx, struct ss_buf *sms_tpdu, size_t *resp
 		tp_ud = sms_tpdu->data + sm_hdr_len;
 		tp_ud_len = sms_tpdu->len - sm_hdr_len;
 		if (sm_hdr.u.sms_deliver.tp_udhi) {
-			if (tp_ud[0] + 1 <= tp_ud_len) {
-				ud_hdr = tp_ud + 1;
-				ud_hdr_len = tp_ud[0];
+			uint8_t ud_hdr_len;
+			const uint8_t *ud_hdr;
 
-				SS_LOGP(SSMS, LDEBUG, "received sms TP-UD header: %s\n",
-					ss_hexdump(ud_hdr, ud_hdr_len));
-				ud_hdr_dec = ss_tlv8_decode(ud_hdr, ud_hdr_len);
-				if (!ud_hdr_dec) {
-					SS_LOGP(SSMS, LERROR, "failed to decode user data header, invalid TLV data\n");
-					*response_len = 0;
-					goto leave;
-				}
-				ss_tlv8_dump(ud_hdr_dec, 2, SSMS, LDEBUG);
-
-				/* Advance pointers to actual user data */
-				tp_ud_len -= 1 + tp_ud[0];
-				tp_ud += 1 + tp_ud[0];
-
-				/* Part of a concatencated SM received, collect partial messages */
-				concat_sm_desc_ie = ss_tlv8_get_ie_minlen(ud_hdr_dec, TS_23_040_IEI_CONCAT_SMS, 3);
-				if (concat_sm_desc_ie) {
-					concat_sm_buf = concat_sm(state, tp_ud, tp_ud_len, concat_sm_desc_ie);
-					if (concat_sm_buf) {
-						rc = handle_sm(ctx, &sm_hdr, ud_hdr, ud_hdr_len, concat_sm_buf->data,
-							       concat_sm_buf->len, response_len, response);
-						ss_buf_free(concat_sm_buf);
-						if (rc < 0)
-							*response_len = 0;
-					}
-				}
-
-			} else {
+			if (tp_ud_len == 0 || tp_ud[0] + 1 > tp_ud_len) {
 				SS_LOGP(SSMS, LERROR,
 					"failed to decode user data header, length field exceeds TP-UD length\n");
 				rc = SS_SW_ERR_WRONG_PARAM_INCORRECT_DATA;
 				*response_len = 0;
 				goto leave;
 			}
+
+			ud_hdr_len = tp_ud[0];
+			ud_hdr = tp_ud + 1;
+			SS_LOGP(SSMS, LDEBUG, "received sms TP-UD header: %s\n", ss_hexdump(ud_hdr, ud_hdr_len));
+
+			rc = parse_ud_hdr(&udh_info, ud_hdr, ud_hdr_len);
+			if (rc != 0) {
+				*response_len = 0;
+				goto leave;
+			}
+
+			tp_ud_len -= 1 + ud_hdr_len;
+			tp_ud += 1 + ud_hdr_len;
+		}
+
+		if (udh_info.concat_present) {
+			rc = process_concat_sm(ctx, state, &sm_hdr, &udh_info, tp_ud, tp_ud_len, response_len, response);
+			break;
 		}
 
 		/* Normal SM received, forward directly */
-		if (!concat_sm_desc_ie) {
-			SS_LOGP(SSMS, LDEBUG, "received sms TP-UD: %s\n", ss_hexdump(tp_ud, tp_ud_len));
-			rc = handle_sm(ctx, &sm_hdr, ud_hdr, ud_hdr_len, tp_ud, tp_ud_len, response_len, response);
-			if (rc < 0)
-				*response_len = 0;
+		SS_LOGP(SSMS, LDEBUG, "received sms TP-UD: %s\n", ss_hexdump(tp_ud, tp_ud_len));
+		rc = decode_ud_hdr(&ud_hdr_dec, udh_info.ud_hdr, udh_info.ud_hdr_len);
+		if (rc == 0)
+			rc = handle_sm(ctx, &sm_hdr, ud_hdr_dec, tp_ud, tp_ud_len, response_len, response);
+		if (rc != 0)
+			*response_len = 0;
+		if (ud_hdr_dec) {
+			ss_tlv8_free(ud_hdr_dec);
+			ud_hdr_dec = NULL;
 		}
 		break;
 	default:
@@ -345,6 +585,7 @@ int ss_uicc_sms_rx(struct ss_context *ctx, struct ss_buf *sms_tpdu, size_t *resp
 	}
 
 leave:
-	ss_tlv8_free(ud_hdr_dec);
+	if (ud_hdr_dec)
+		ss_tlv8_free(ud_hdr_dec);
 	return rc;
 }

--- a/src/softsim/uicc/uicc_sms_rx.h
+++ b/src/softsim/uicc/uicc_sms_rx.h
@@ -6,22 +6,15 @@
 
 #pragma once
 
+#include <stddef.h>
+#include <onomondo/softsim/list.h>
 #include "sms.h"
-
-struct ss_uicc_sms_rx_sm {
-	struct ss_list list;
-	uint8_t msg_id;
-	uint8_t msg_part_no;
-	uint8_t tp_ud[SMS_MAX_SIZE];
-	size_t tp_ud_len;
-};
 
 /* Note: It is expected that the contents of ss_uicc_sms_rx_state are set to
  * zero before carrying out any operation, including ss_uicc_sms_rx_clear() */
 struct ss_uicc_sms_rx_state {
-	uint8_t msg_id;
-	uint8_t msg_parts;
-	struct ss_list sm;
+	struct ss_list reassemblies;
+	size_t reassembly_count;
 };
 
 struct ss_buf;

--- a/tests/sms/CMakeLists.txt
+++ b/tests/sms/CMakeLists.txt
@@ -6,6 +6,6 @@ add_executable(sms_test sms_test.c)
 include_directories(${PROJECT_SOURCE_DIR})
 include_directories(${PROJECT_SOURCE_DIR}/include)
 
-target_link_libraries(sms_test uicc)
+target_link_libraries(sms_test uicc milenage crypto storage $<$<TARGET_EXISTS:utils>:utils>)
 
 add_test(NAME sms_test COMMAND sh -c "$<TARGET_FILE:sms_test> > sms_test.out")

--- a/tests/sms/sms_test.c
+++ b/tests/sms/sms_test.c
@@ -9,9 +9,12 @@
 #include <stdio.h>
 #include <stdbool.h>
 #include <stddef.h>
+#include <string.h>
 #include <onomondo/softsim/utils.h>
 #include <onomondo/softsim/list.h>
+#include "src/softsim/uicc/sw.h"
 #include "src/softsim/uicc/sms.h"
+#include "src/softsim/uicc/uicc_sms_rx.h"
 #include "src/softsim/uicc/uicc_sms_tx.h"
 #include "src/softsim/uicc/context.h"
 
@@ -19,6 +22,7 @@
 static void ready_ctx(struct ss_context *ctx)
 {
 	memset(ctx, 0, sizeof(*ctx));
+	ss_uicc_sms_rx_clear(ctx);
 	ss_uicc_sms_tx_clear(ctx);
 	/* Simulate context that set all the relevant bits */
 	ctx->proactive.term_profile[0] = 0xff;
@@ -302,6 +306,264 @@ void ss_uicc_sms_tx_test_multi(void)
 	ss_uicc_sms_tx_clear(&ctx);
 }
 
+static size_t make_sms_deliver_with_udhl(uint8_t *sms_tpdu, size_t sms_tpdu_len, const uint8_t tp_oa[4],
+					 uint8_t udhl, const uint8_t *ud_hdr, size_t ud_hdr_len,
+					 const uint8_t *tp_ud, size_t tp_ud_len)
+{
+	static const uint8_t scts[7] = { 0x00, 0x11, 0x29, 0x12, 0x00, 0x00, 0x04 };
+	size_t pos = 0;
+	size_t tp_udl = 1 + ud_hdr_len + tp_ud_len;
+
+	assert(tp_udl <= 255);
+	assert(sms_tpdu_len >= 18 + ud_hdr_len + tp_ud_len);
+
+	sms_tpdu[pos++] = 0x40; /* SMS-DELIVER with TP-UDHI */
+	sms_tpdu[pos++] = 0x08;
+	sms_tpdu[pos++] = 0x81;
+	memcpy(&sms_tpdu[pos], tp_oa, 4);
+	pos += 4;
+	sms_tpdu[pos++] = 0x7f;
+	sms_tpdu[pos++] = 0xf6;
+	memcpy(&sms_tpdu[pos], scts, sizeof(scts));
+	pos += sizeof(scts);
+	sms_tpdu[pos++] = (uint8_t)tp_udl;
+	sms_tpdu[pos++] = udhl;
+	if (ud_hdr_len > 0) {
+		memcpy(&sms_tpdu[pos], ud_hdr, ud_hdr_len);
+		pos += ud_hdr_len;
+	}
+	if (tp_ud_len > 0) {
+		memcpy(&sms_tpdu[pos], tp_ud, tp_ud_len);
+		pos += tp_ud_len;
+	}
+
+	return pos;
+}
+
+static size_t make_sms_deliver(uint8_t *sms_tpdu, size_t sms_tpdu_len, const uint8_t tp_oa[4],
+			       const uint8_t *ud_hdr, size_t ud_hdr_len, const uint8_t *tp_ud, size_t tp_ud_len)
+{
+	assert(ud_hdr_len <= 255);
+	return make_sms_deliver_with_udhl(sms_tpdu, sms_tpdu_len, tp_oa, (uint8_t)ud_hdr_len, ud_hdr,
+					  ud_hdr_len, tp_ud, tp_ud_len);
+}
+
+static int sms_rx_part(struct ss_context *ctx, const uint8_t tp_oa[4], const uint8_t *ud_hdr, size_t ud_hdr_len,
+		       const uint8_t *tp_ud, size_t tp_ud_len, size_t *response_len)
+{
+	uint8_t sms_tpdu[256];
+	uint8_t response[256];
+	struct ss_buf buf;
+	size_t sms_tpdu_len;
+
+	sms_tpdu_len = make_sms_deliver(sms_tpdu, sizeof(sms_tpdu), tp_oa, ud_hdr, ud_hdr_len, tp_ud, tp_ud_len);
+	buf.data = sms_tpdu;
+	buf.len = sms_tpdu_len;
+	*response_len = sizeof(response);
+	return ss_uicc_sms_rx(ctx, &buf, response_len, response);
+}
+
+static void expect_sms_rx_part(struct ss_context *ctx, const uint8_t tp_oa[4], const uint8_t *ud_hdr,
+			       size_t ud_hdr_len, const uint8_t *tp_ud, size_t tp_ud_len, int expected_rc,
+			       size_t expected_response_len)
+{
+	size_t response_len;
+	int rc;
+
+	rc = sms_rx_part(ctx, tp_oa, ud_hdr, ud_hdr_len, tp_ud, tp_ud_len, &response_len);
+	assert(rc == expected_rc);
+	assert(response_len == expected_response_len);
+}
+
+static void ss_uicc_sms_rx_concat_8bit_test(void)
+{
+	static const uint8_t tp_oa[4] = { 0x55, 0x66, 0x77, 0x88 };
+	struct ss_context ctx;
+	uint8_t udh_1[] = { 0x00, 0x03, 0x21, 0x02, 0x01 };
+	uint8_t udh_2[] = { 0x00, 0x03, 0x21, 0x02, 0x02 };
+	uint8_t tp_ud_1[] = { 0xde, 0xad };
+	uint8_t tp_ud_2[] = { 0xbe, 0xef };
+
+	printf("test ss_uicc_sms_rx concat 8-bit\n");
+	ready_ctx(&ctx);
+	expect_sms_rx_part(&ctx, tp_oa, udh_1, sizeof(udh_1), tp_ud_1, sizeof(tp_ud_1), 0, 0);
+	assert(ctx.proactive.sms_rx_state.reassembly_count == 1);
+	expect_sms_rx_part(&ctx, tp_oa, udh_2, sizeof(udh_2), tp_ud_2, sizeof(tp_ud_2), 0, 0);
+	assert(ctx.proactive.sms_rx_state.reassembly_count == 0);
+	ss_uicc_sms_rx_clear(&ctx);
+}
+
+static void ss_uicc_sms_rx_concat_16bit_test(void)
+{
+	static const uint8_t tp_oa[4] = { 0x55, 0x66, 0x77, 0x88 };
+	struct ss_context ctx;
+	uint8_t udh_1[] = { 0x08, 0x04, 0x12, 0x34, 0x02, 0x01 };
+	uint8_t udh_2[] = { 0x08, 0x04, 0x12, 0x34, 0x02, 0x02 };
+	uint8_t tp_ud_1[] = { 0x10 };
+	uint8_t tp_ud_2[] = { 0x20 };
+
+	printf("test ss_uicc_sms_rx concat 16-bit\n");
+	ready_ctx(&ctx);
+	expect_sms_rx_part(&ctx, tp_oa, udh_1, sizeof(udh_1), tp_ud_1, sizeof(tp_ud_1), 0, 0);
+	assert(ctx.proactive.sms_rx_state.reassembly_count == 1);
+	expect_sms_rx_part(&ctx, tp_oa, udh_2, sizeof(udh_2), tp_ud_2, sizeof(tp_ud_2), 0, 0);
+	assert(ctx.proactive.sms_rx_state.reassembly_count == 0);
+	ss_uicc_sms_rx_clear(&ctx);
+}
+
+static void ss_uicc_sms_rx_concat_out_of_order_test(void)
+{
+	static const uint8_t tp_oa[4] = { 0x55, 0x66, 0x77, 0x88 };
+	struct ss_context ctx;
+	uint8_t udh_1[] = { 0x00, 0x03, 0x22, 0x02, 0x01 };
+	uint8_t udh_2[] = { 0x00, 0x03, 0x22, 0x02, 0x02 };
+	uint8_t tp_ud_1[] = { 0x01 };
+	uint8_t tp_ud_2[] = { 0x02 };
+
+	printf("test ss_uicc_sms_rx concat out-of-order\n");
+	ready_ctx(&ctx);
+	expect_sms_rx_part(&ctx, tp_oa, udh_2, sizeof(udh_2), tp_ud_2, sizeof(tp_ud_2), 0, 0);
+	assert(ctx.proactive.sms_rx_state.reassembly_count == 1);
+	expect_sms_rx_part(&ctx, tp_oa, udh_1, sizeof(udh_1), tp_ud_1, sizeof(tp_ud_1), 0, 0);
+	assert(ctx.proactive.sms_rx_state.reassembly_count == 0);
+	ss_uicc_sms_rx_clear(&ctx);
+}
+
+static void ss_uicc_sms_rx_concat_duplicate_test(void)
+{
+	static const uint8_t tp_oa[4] = { 0x55, 0x66, 0x77, 0x88 };
+	struct ss_context ctx;
+	uint8_t udh_1[] = { 0x00, 0x03, 0x23, 0x02, 0x01 };
+	uint8_t udh_2[] = { 0x00, 0x03, 0x23, 0x02, 0x02 };
+	uint8_t tp_ud_1[] = { 0x01 };
+	uint8_t tp_ud_2[] = { 0x02 };
+
+	printf("test ss_uicc_sms_rx concat duplicate\n");
+	ready_ctx(&ctx);
+	expect_sms_rx_part(&ctx, tp_oa, udh_1, sizeof(udh_1), tp_ud_1, sizeof(tp_ud_1), 0, 0);
+	expect_sms_rx_part(&ctx, tp_oa, udh_1, sizeof(udh_1), tp_ud_1, sizeof(tp_ud_1), 0, 0);
+	assert(ctx.proactive.sms_rx_state.reassembly_count == 1);
+	expect_sms_rx_part(&ctx, tp_oa, udh_2, sizeof(udh_2), tp_ud_2, sizeof(tp_ud_2), 0, 0);
+	assert(ctx.proactive.sms_rx_state.reassembly_count == 0);
+	ss_uicc_sms_rx_clear(&ctx);
+}
+
+static void ss_uicc_sms_rx_concat_conflicting_duplicate_test(void)
+{
+	static const uint8_t tp_oa[4] = { 0x55, 0x66, 0x77, 0x88 };
+	struct ss_context ctx;
+	uint8_t udh_1[] = { 0x00, 0x03, 0x24, 0x02, 0x01 };
+	uint8_t tp_ud_1[] = { 0x01 };
+	uint8_t tp_ud_1_conflict[] = { 0x99 };
+
+	printf("test ss_uicc_sms_rx concat conflicting duplicate\n");
+	ready_ctx(&ctx);
+	expect_sms_rx_part(&ctx, tp_oa, udh_1, sizeof(udh_1), tp_ud_1, sizeof(tp_ud_1), 0, 0);
+	assert(ctx.proactive.sms_rx_state.reassembly_count == 1);
+	expect_sms_rx_part(&ctx, tp_oa, udh_1, sizeof(udh_1), tp_ud_1_conflict, sizeof(tp_ud_1_conflict),
+			   SS_SW_ERR_WRONG_PARAM_INCORRECT_DATA, 0);
+	assert(ctx.proactive.sms_rx_state.reassembly_count == 0);
+	ss_uicc_sms_rx_clear(&ctx);
+}
+
+static void ss_uicc_sms_rx_concat_interleaved_test(void)
+{
+	static const uint8_t tp_oa[4] = { 0x55, 0x66, 0x77, 0x88 };
+	struct ss_context ctx;
+	uint8_t udh_a1[] = { 0x00, 0x03, 0x31, 0x02, 0x01 };
+	uint8_t udh_a2[] = { 0x00, 0x03, 0x31, 0x02, 0x02 };
+	uint8_t udh_b1[] = { 0x00, 0x03, 0x32, 0x02, 0x01 };
+	uint8_t udh_b2[] = { 0x00, 0x03, 0x32, 0x02, 0x02 };
+	uint8_t tp_ud[] = { 0x01 };
+
+	printf("test ss_uicc_sms_rx concat interleaved refs\n");
+	ready_ctx(&ctx);
+	expect_sms_rx_part(&ctx, tp_oa, udh_a1, sizeof(udh_a1), tp_ud, sizeof(tp_ud), 0, 0);
+	expect_sms_rx_part(&ctx, tp_oa, udh_b1, sizeof(udh_b1), tp_ud, sizeof(tp_ud), 0, 0);
+	assert(ctx.proactive.sms_rx_state.reassembly_count == 2);
+	expect_sms_rx_part(&ctx, tp_oa, udh_a2, sizeof(udh_a2), tp_ud, sizeof(tp_ud), 0, 0);
+	assert(ctx.proactive.sms_rx_state.reassembly_count == 1);
+	expect_sms_rx_part(&ctx, tp_oa, udh_b2, sizeof(udh_b2), tp_ud, sizeof(tp_ud), 0, 0);
+	assert(ctx.proactive.sms_rx_state.reassembly_count == 0);
+	ss_uicc_sms_rx_clear(&ctx);
+}
+
+static void ss_uicc_sms_rx_concat_same_ref_different_originator_test(void)
+{
+	static const uint8_t tp_oa_a[4] = { 0x55, 0x66, 0x77, 0x88 };
+	static const uint8_t tp_oa_b[4] = { 0x55, 0x66, 0x77, 0x98 };
+	struct ss_context ctx;
+	uint8_t udh_1[] = { 0x00, 0x03, 0x33, 0x02, 0x01 };
+	uint8_t udh_2[] = { 0x00, 0x03, 0x33, 0x02, 0x02 };
+	uint8_t tp_ud[] = { 0x01 };
+
+	printf("test ss_uicc_sms_rx concat same ref different originator\n");
+	ready_ctx(&ctx);
+	expect_sms_rx_part(&ctx, tp_oa_a, udh_1, sizeof(udh_1), tp_ud, sizeof(tp_ud), 0, 0);
+	expect_sms_rx_part(&ctx, tp_oa_b, udh_1, sizeof(udh_1), tp_ud, sizeof(tp_ud), 0, 0);
+	assert(ctx.proactive.sms_rx_state.reassembly_count == 2);
+	expect_sms_rx_part(&ctx, tp_oa_a, udh_2, sizeof(udh_2), tp_ud, sizeof(tp_ud), 0, 0);
+	assert(ctx.proactive.sms_rx_state.reassembly_count == 1);
+	expect_sms_rx_part(&ctx, tp_oa_b, udh_2, sizeof(udh_2), tp_ud, sizeof(tp_ud), 0, 0);
+	assert(ctx.proactive.sms_rx_state.reassembly_count == 0);
+	ss_uicc_sms_rx_clear(&ctx);
+}
+
+static void ss_uicc_sms_rx_concat_cpi_first_part_only_test(void)
+{
+	static const uint8_t tp_oa[4] = { 0x55, 0x66, 0x77, 0x88 };
+	struct ss_context ctx;
+	uint8_t udh_1[] = { 0x00, 0x03, 0x34, 0x02, 0x01, 0x70, 0x01, 0xaa };
+	uint8_t udh_2[] = { 0x00, 0x03, 0x34, 0x02, 0x02 };
+	uint8_t tp_ud_1[] = { 0xde };
+	uint8_t tp_ud_2[] = { 0xad };
+
+	printf("test ss_uicc_sms_rx concat CPI on first part only\n");
+	ready_ctx(&ctx);
+	expect_sms_rx_part(&ctx, tp_oa, udh_1, sizeof(udh_1), tp_ud_1, sizeof(tp_ud_1), 0, 0);
+	assert(ctx.proactive.sms_rx_state.reassembly_count == 1);
+	expect_sms_rx_part(&ctx, tp_oa, udh_2, sizeof(udh_2), tp_ud_2, sizeof(tp_ud_2),
+			   SS_SW_ERR_CHECKING_WRONG_LENGTH, 0);
+	assert(ctx.proactive.sms_rx_state.reassembly_count == 0);
+	ss_uicc_sms_rx_clear(&ctx);
+}
+
+static void ss_uicc_sms_rx_concat_malformed_test(void)
+{
+	static const uint8_t tp_oa[4] = { 0x55, 0x66, 0x77, 0x88 };
+	struct ss_context ctx;
+	uint8_t sms_tpdu[256];
+	uint8_t response[256];
+	struct ss_buf buf;
+	size_t sms_tpdu_len;
+	size_t response_len;
+	int rc;
+	uint8_t malformed_concat[] = { 0x00, 0x02, 0x41, 0x02 };
+	uint8_t invalid_seq[] = { 0x00, 0x03, 0x41, 0x02, 0x00 };
+	uint8_t tp_ud[] = { 0x01 };
+
+	printf("test ss_uicc_sms_rx concat malformed\n");
+	ready_ctx(&ctx);
+
+	sms_tpdu_len = make_sms_deliver_with_udhl(sms_tpdu, sizeof(sms_tpdu), tp_oa, 5, NULL, 0, NULL, 0);
+	buf.data = sms_tpdu;
+	buf.len = sms_tpdu_len;
+	response_len = sizeof(response);
+	rc = ss_uicc_sms_rx(&ctx, &buf, &response_len, response);
+	assert(rc == SS_SW_ERR_WRONG_PARAM_INCORRECT_DATA);
+	assert(response_len == 0);
+	assert(ctx.proactive.sms_rx_state.reassembly_count == 0);
+
+	expect_sms_rx_part(&ctx, tp_oa, malformed_concat, sizeof(malformed_concat), tp_ud, sizeof(tp_ud),
+			   SS_SW_ERR_WRONG_PARAM_INCORRECT_DATA, 0);
+	assert(ctx.proactive.sms_rx_state.reassembly_count == 0);
+
+	expect_sms_rx_part(&ctx, tp_oa, invalid_seq, sizeof(invalid_seq), tp_ud, sizeof(tp_ud),
+			   SS_SW_ERR_WRONG_PARAM_INCORRECT_DATA, 0);
+	assert(ctx.proactive.sms_rx_state.reassembly_count == 0);
+	ss_uicc_sms_rx_clear(&ctx);
+}
+
 int main(int argc, char **argv)
 {
 	ss_sms_hdr_decode_sms_deliver_test();
@@ -312,5 +574,14 @@ int main(int argc, char **argv)
 	ss_sms_hdr_encode_test_sms_submit();
 	ss_uicc_sms_tx_test_single();
 	ss_uicc_sms_tx_test_multi();
+	ss_uicc_sms_rx_concat_8bit_test();
+	ss_uicc_sms_rx_concat_16bit_test();
+	ss_uicc_sms_rx_concat_out_of_order_test();
+	ss_uicc_sms_rx_concat_duplicate_test();
+	ss_uicc_sms_rx_concat_conflicting_duplicate_test();
+	ss_uicc_sms_rx_concat_interleaved_test();
+	ss_uicc_sms_rx_concat_same_ref_different_originator_test();
+	ss_uicc_sms_rx_concat_cpi_first_part_only_test();
+	ss_uicc_sms_rx_concat_malformed_test();
 	return 0;
 }


### PR DESCRIPTION
## Summary

Adds robust concatenated SMS-PP Data Download support before OTA command handling. SMS-PP parts are now reassembled across multiple ENVELOPE commands before being passed to the remote command parser, allowing long OTA payloads to be received reliably.

## Changes

- Adds bounded SMS-PP reassembly state for up to 4 concurrent concatenated messages.
- Supports both 8-bit and 16-bit concatenation UDH references.
- Handles out-of-order parts, interleaved messages, exact duplicates, and conflicting duplicates.
- Keys reassemblies by originator address, TP-PID, TP-DCS, concat reference, reference width, and total part count.
- Preserves non-concat UDH metadata so CPI `0x70` can still be detected after reassembly.
- Rejects malformed UDH/concat metadata instead of silently continuing.
- Returns success with no response data for incomplete concat parts.
- Propagates SMS RX errors through the SMS-PP ENVELOPE handler.
- Expands SMS RX unit coverage for concat happy paths, malformed input, duplicates, interleaving, and CPI handling.

## Testing

Verified with:

```sh
cmake -S . -B /private/tmp/onomondo-uicc-sms-check -DBUILD_TESTING=ON
cmake --build /private/tmp/onomondo-uicc-sms-check --target sms_test
ctest --test-dir /private/tmp/onomondo-uicc-sms-check -R sms_test --output-on-failure
```

<img width="1280" height="465" alt="Screenshot 2026-05-19 at 1 57 33 PM" src="https://github.com/user-attachments/assets/b9dc9e82-84ec-40f6-ba68-a63784952dab" />
