### PR TITLE
fix: allow APDU responses shorter than requested Le

### DIFF
--- a/src/softsim/uicc/softsim.c
+++ b/src/softsim/uicc/softsim.c
@@ -343,10 +343,10 @@ out:
 	} else {
 		if (apdu->le == 0) {
 			SS_LOGP(SLCHAN, LDEBUG, "Returning rsp_len = %zu bytes after le = 0\n", apdu->rsp_len);
-		} else if (apdu->le != apdu->rsp_len) {
+		} else if (apdu->rsp_len > apdu->le) {
 			SS_LOGP(SLCHAN, LERROR,
-				"invalid response data, le (%u) != rsp_len (%lu), changing SW=%04x to SW=%04x (wrong length)\n",
-				apdu->le, apdu->rsp_len, apdu->sw, SS_SW_ERR_CHECKING_WRONG_LENGTH);
+				"invalid response data, rsp_len (%lu) > le (%u), changing SW=%04x to SW=%04x (wrong length)\n",
+				apdu->rsp_len, apdu->le, apdu->sw, SS_SW_ERR_CHECKING_WRONG_LENGTH);
 			apdu->sw = SS_SW_ERR_CHECKING_WRONG_LENGTH;
 			apdu->rsp_len = 0;
 		}


### PR DESCRIPTION
`softsim.c` validates APDU responses with:

```c
} else if (apdu->le != apdu->rsp_len) {
    apdu->sw = SS_SW_ERR_CHECKING_WRONG_LENGTH;  // SW=6700
```
This fires whenever the card returns fewer bytes than the terminal requested — which is valid behaviour per ISO 7816-4.

Concrete trigger: STATUS APDU `80 F2 00 00 00`. The le=0x00 short form is correctly decoded to 256 by apdu.c. The STATUS handler returns ~50 bytes of FCP/TLV data. The != check then overwrites SW=9000 with SW=6700, causing the modem to abort whatever operation was in progress.