### PR TITLE
ci: pin all GitHub Actions to fixed SHAs

### DIFF
--- a/.github/workflows/ci_uicc.yml
+++ b/.github/workflows/ci_uicc.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.10"
 
@@ -47,13 +47,13 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install CMake
-        uses: lukka/get-cmake@latest
+        uses: lukka/get-cmake@591817e96fcad43505fb4eae36172462abb3a42e # v4.3.3
         with:
           cmakeVersion: 3.27.0
           ninjaVersion: 1.11.1
 
       - name: Install Embedded Toolchain
-        uses: carlosperate/arm-none-eabi-gcc-action@v1.11.1
+        uses: carlosperate/arm-none-eabi-gcc-action@4c88c61a77a39a33a7722d24a4e8b2c573f766c9 # v1.11.1
         if: matrix.compiler == 'gcc'
 
       - name: Install CLANG


### PR DESCRIPTION
Pin previously floating action references to immutable commit SHAs to prevent supply-chain attacks and ensure reproducible CI runs.

- actions/setup-python@v5 → @a26af69be951a213d495a4c3e4e4022e16d87065
- lukka/get-cmake@latest  → @591817e96fcad43505fb4eae36172462abb3a42e (v4.3.3)
- carlosperate/arm-none-eabi-gcc-action@v1.11.1 → @4c88c61a77a39a33a7722d24a4e8b2c573f766c9