### PR TITLE
fix: clamp in_len to key buffer size in ss_load_key_external

### DIFF
--- a/utils/ss_crypto_extension.c
+++ b/utils/ss_crypto_extension.c
@@ -12,6 +12,8 @@
 
 void ss_load_key_external(const uint8_t *key_id, size_t in_len, uint8_t *key, size_t *key_len)
 {
+	if (in_len > *key_len)
+		in_len = *key_len;
 	memcpy(key, key_id, in_len);
 	*key_len = in_len;
 }


### PR DESCRIPTION
Without this guard, a caller supplying an in_len larger than the allocated key buffer causes a heap buffer overflow, potentially overwriting adjacent memory including cryptographic key material.

Clamp in_len to *key_len (the callee-provided buffer capacity) before the memcpy, matching the documented in/out semantics of key_len.

Closes #50