### PR TITLE
ci: add explicit least-privilege permissions to workflows

### DIFF
--- a/.github/workflows/ci_uicc.yml
+++ b/.github/workflows/ci_uicc.yml
@@ -6,6 +6,9 @@ on:
       - master
   pull_request:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/pr_commit_checks.yml
+++ b/.github/workflows/pr_commit_checks.yml
@@ -3,6 +3,10 @@ name: PR Commit Checks
 on:
   pull_request:
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   pr-commit-checks:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
Add top-level permissions blocks to ci_uicc.yml and pr_commit_checks.yml to explicitly restrict the GITHUB_TOKEN to the minimum required scope, preventing accidental write access if the org-level default is permissive.