### PR TITLE
fix: reject extended-length APDUs at the dispatcher

### DIFF
--- a/src/softsim/uicc/softsim.c
+++ b/src/softsim/uicc/softsim.c
@@ -194,6 +194,19 @@ static int apdu_transact(struct ss_context *ctx, struct ss_apdu *apdu)
 	 * error cases. */
 	ss_fs_utils_path_clone(&backup_path, &apdu->lchan->fs_path);
 
+	/* Card ATR advertises no extended-length APDU support,
+	 * reject with SW=6700 ("wrong length"). */
+	if (apdu->le > 256 || apdu->lc > 256) {
+		SS_LOGP(SLCHAN, LERROR,
+			"extended-length APDU rejected: lc=%u, le=%u (card advertises no extended-length support)\n",
+			apdu->lc, apdu->le);
+		apdu->sw = SS_SW_ERR_CHECKING_WRONG_LENGTH;
+		apdu->lc = 0;
+		apdu->le = 0;
+		apdu->rsp_len = 0;
+		goto out;
+	}
+
 	if (((apdu->hdr.cla & 0x70) == 0x00) && apdu->hdr.ins == TS_102_221_INS_GET_RESPONSE) {
 		/* The GET RESPONSE command is of command case 2 (see also command.h) */
 		processed_length = 5;


### PR DESCRIPTION
The ATR's card-capabilities byte 3 bit 7 = 0 declares "no extended Lc/Le support", but the parser at ss_apdu_parse_exhaustive accepts extended APDUs anyway. apdu->cmd[256] and apdu->rsp[256] are fixed-size buffers that cannot hold extended payloads.

Reject extended-length APDUs centrally in apdu_transact() with SW=6700 ("wrong length"). Placed after ss_fs_utils_path_clone() so the out:-label tail can safely run ss_path_reset(&backup_path).

Also annotate the ATR byte-by-byte so the "no extended length" claim is visible without decoding the array by hand. The new comment on card-capabilities byte 3 calls out the bit that ties the ATR to this dispatcher reject.