### PR TITLE
fix: prevent apdu->cmd[256] overflow on extended Lc APDUs

### DIFF
--- a/src/softsim/uicc/apdu.c
+++ b/src/softsim/uicc/apdu.c
@@ -187,8 +187,7 @@ out:
 	apdu->lc = lc;
 	apdu->le = le;
 	apdu->processed_bytes = processed_bytes;
-	// copy data field if present
-	if (lc && data_start) {
+	if (lc && data_start && lc <= sizeof(apdu->cmd)) {
 		memcpy(apdu->cmd, data_start, lc);
 	}
 }


### PR DESCRIPTION
The dispatcher in apdu_transact() returns SW=6700 for extended-length APDUs, but ss_apdu_parse_exhaustive() copies the data field into apdu->cmd before the dispatcher runs. For an extended Case-3/4 APDU with Lc > 256, that memcpy overflows apdu->cmd[256] at parse time.

Guard the memcpy with lc <= sizeof(apdu->cmd). apdu->lc is left at its true value so the dispatcher still sees the over-length APDU and returns SW=6700 to the terminal — only the unsafe write is skipped.

Close #55 