### PR TITLE
fix: return negative SW from parse_cmd_hdr_clrtxt on packet-too-short

### DIFF
--- a/src/softsim/uicc/uicc_remote_cmd.c
+++ b/src/softsim/uicc/uicc_remote_cmd.c
@@ -151,7 +151,7 @@ static int parse_cmd_hdr_clrtxt(struct command_parameters *param, size_t cmd_pac
 		SS_LOGP(SREMOTECMD, LERROR, "Received comand packet too short\n");
 		/* Is there any better guidance? This is only based on general ISO 7816
 		 * ENVELOPE descriptions. */
-		return SS_SW_ERR_CHECKING_WRONG_LENGTH;
+		return -SS_SW_ERR_CHECKING_WRONG_LENGTH;
 	}
 
 	SS_LOGP(SREMOTECMD, LDEBUG, "command packet header data (cleartext): %s\n", ss_hexdump(cmd_packet, 10));


### PR DESCRIPTION
The packet-too-short early-return previously returned the positive constant SS_SW_ERR_CHECKING_WRONG_LENGTH (0x6700). 0x6700 > 0, so the `if (ret <= 0)` check fails.

Negate the return value so the error-code convention is honored.