### PR TITLE
fix: propagate SMS-RX error from SMS-PP ENVELOPE handler

### DIFF
--- a/src/softsim/uicc/uicc_cat.c
+++ b/src/softsim/uicc/uicc_cat.c
@@ -66,7 +66,7 @@ int handle_sms_pp_dwnld(struct ss_apdu *apdu, struct ss_buf *cat_template)
 
 leave:
 	ss_ctlv_free(ctlv_data);
-	return 0;
+	return rc;
 }
 
 const struct ss_cat_envelope_command cat_envelope_commands[] = {


### PR DESCRIPTION
handle_sms_pp_dwnld() captures the return code from ss_uicc_sms_rx into rc, uses it to clear apdu->rsp_len on failure, and then unconditionally returns 0. The caller (the ENVELOPE command dispatcher in ss_uicc_cat_cmd_envelope) treats the handler's return value as the SW to deliver to the terminal — so every SMS-PP DOWNLOAD currently returns SW=9000 to the terminal regardless of whether the SMS RX path actually succeeded.