### PR TITLE
docs: correct TAR spec citation to TS 101 220

### DIFF
--- a/src/softsim/uicc/uicc_remote_cmd.c
+++ b/src/softsim/uicc/uicc_remote_cmd.c
@@ -363,7 +363,7 @@ static int parse_cmd_hdr_ciphtxt(struct command_parameters *param, size_t cmd_pa
  *   choice. */
 static void setup_ctx_from_tar(struct ss_context *ctx, uint8_t *tar)
 {
-	/* Values from TS 101 221 Annex D. When extending, take care not to use any
+	/* Values from TS 101 220 Annex D. When extending, take care not to use any
 	 * TARs that imply extended data format unless that is implemented and
 	 * signalled to the decoder. */
 


### PR DESCRIPTION
The comment in setup_ctx_from_tar referenced "TS 101 221". The TAR
values the function branches on (B0 00 10 to B0 00 1F for the SIM File
System) are listed in ETSI TS 101 220 v19.0.0 Annex D, Table D.1.