### PR TITLE
fix: return success from GSM-context AUTHENTICATE

### DIFF
--- a/src/softsim/uicc/uicc_auth.c
+++ b/src/softsim/uicc/uicc_auth.c
@@ -252,7 +252,10 @@ static int authenticate_milenage(struct ss_apdu *apdu, enum usim_auth_ctx auth_c
 		apdu->rsp[0] = 4; /* length of SRES */
 		apdu->rsp[1 + 4] = 8; /* length of Kc */
 		apdu->rsp_len = 1 + 4 + 1 + 8;
-		break;
+		/* GSM context success: deliver SRES/Kc with SW=9000. A break here
+		 * would fall through to out_err and return -1, which the dispatcher
+		 * maps to SW=6F00. */
+		return 0;
 	case USIM_AUTH_CTX_3G:
 		if (rand_len != 128 / 8) {
 			SS_LOGP(SAUTH, LERROR, "unexpected RAND len -- authentication failed\n");


### PR DESCRIPTION
A GSM-context AUTHENTICATE builds a valid SRES/Kc response into `apdu->rsp` and sets `apdu->rsp_len`, then executes `break;`. That break exits only the `switch (auth_ctx)` and falls through to the `out_err:` label, returning -1.

The command dispatcher (softsim.c) maps a negative handler return to SS_SW_ERR_CHECKING_NO_PRECISE_DIAG (0x6F00), so a successful GSM authentication was reported to the terminal as 6F00 and the modem aborted the auth session.

Return 0 instead, mirroring the 3G success and resync paths. The prepared SRES/Kc are then delivered the normal CASE 4 way: the dispatcher signals SW=61xx, and the terminal fetches the 14-byte `[04 SRES 08 Kc]` body with a
GET RESPONSE that returns SW=9000.

No SEQ update is needed (GSM authentication has no SQN), and out_err's `memset(&mres, ...)` protects nothing here: gsm_milenage() writes SRES/Kc directly into apdu->rsp and never touches mres, which stays zero from the
memset at function entry.

Fixes #60