### PR TITLE
style: remove trailing semicolons from allocation and utility macros

### DIFF
--- a/include/onomondo/softsim/mem.h
+++ b/include/onomondo/softsim/mem.h
@@ -6,6 +6,8 @@
 
 #pragma once
 
+#include <stddef.h>
+
 #ifdef CONFIG_USE_SYSTEM_HEAP
 #include <stdlib.h>
 #define SS_ALLOC(obj) malloc(sizeof(obj))
@@ -14,7 +16,7 @@
 #else /* !CONFIG_USE_SYSTEM_HEAP */
 void *port_malloc(size_t);
 void port_free(void *);
-#define SS_ALLOC(obj) port_malloc(sizeof(obj));
-#define SS_ALLOC_N(n) port_malloc(n);
-#define SS_FREE(obj) port_free(obj);
+#define SS_ALLOC(obj) port_malloc(sizeof(obj))
+#define SS_ALLOC_N(n) port_malloc(n)
+#define SS_FREE(obj) port_free(obj)
 #endif /* !CONFIG_USE_SYSTEM_HEAP */

--- a/src/softsim/uicc/utils_aes.c
+++ b/src/softsim/uicc/utils_aes.c
@@ -26,7 +26,7 @@
 	key = modified_key;                                                  \
 	key_len = modified_key_len;
 
-#define MEMZERO_EXTERNAL_KEY() ss_memzero(modified_key, sizeof(modified_key));
+#define MEMZERO_EXTERNAL_KEY() ss_memzero(modified_key, sizeof(modified_key))
 
 #ifndef CONFIG_EXTERNAL_CRYPTO_IMPL
 
@@ -64,7 +64,7 @@ void ss_utils_aes_decrypt(uint8_t *buffer, size_t buffer_len, const uint8_t *key
 	aes_decrypt_deinit(aes_ctx);
 
 #ifdef CONFIG_EXTERNAL_KEY_LOAD
-	MEMZERO_EXTERNAL_KEY()
+	MEMZERO_EXTERNAL_KEY();
 #endif // CONFIG_EXTERNAL_KEY_LOAD
 }
 
@@ -99,7 +99,7 @@ void ss_utils_aes_encrypt(uint8_t *buffer, size_t buffer_len, const uint8_t *key
 	aes_encrypt_deinit(aes_ctx);
 
 #ifdef CONFIG_EXTERNAL_KEY_LOAD
-	MEMZERO_EXTERNAL_KEY()
+	MEMZERO_EXTERNAL_KEY();
 #endif // CONFIG_EXTERNAL_KEY_LOAD
 }
 #endif // CONFIG_EXTERNAL_CRYPTO_IMPL


### PR DESCRIPTION
Including semicolons in macro definitions is a bad practice that can lead to syntax errors in control structures (e.g., if/else blocks without braces) and prevents macros from being used as expressions.

Changes:
- Updated `include/onomondo/softsim/mem.h` (SS_ALLOC, SS_ALLOC_N, SS_FREE)
- Updated `src/softsim/uicc/utils_aes.c` (MEMZERO_EXTERNAL_KEY)