### PR TITLE
fix: guard NULL apdu->lchan on unsuccessful response to prevent segfault

### DIFF
--- a/src/softsim/uicc/softsim.c
+++ b/src/softsim/uicc/softsim.c
@@ -186,6 +186,7 @@ static int apdu_transact(struct ss_context *ctx, struct ss_apdu *apdu)
 	struct ss_apdu *last_apdu = NULL;
 
 	int processed_length = -1;
+	ss_list_init(&backup_path);
 
 	SS_LOGP(SLCHAN, LDEBUG, "------------------------- transaction begins ------------------------\n");
 
@@ -385,7 +386,8 @@ out:
 		SS_LOGP(SLCHAN, LDEBUG, "Tx R-APDU SW=%04x\n", apdu->sw);
 	}
 
-	if (!ss_sw_is_successful(apdu->sw)
+	if (apdu->lchan &&
+	    !ss_sw_is_successful(apdu->sw)
 	    /* If the command just fails with "wrong length", it usually didn't change the path */
 	    && (apdu->sw >> 8) != 0x6c) {
 		SS_LOGP(SLCHAN, LINFO, "Unsuccessful response %04x, restoring backup path.\n", apdu->sw);


### PR DESCRIPTION
During one of my first tests bridging this softsim into my phone through my own emulator, I have encountered a segmentation fault. Providing the fix for it.

My fix works, but more attention is advised – I haven't checked interaction between the other internal parts.

### Reproduce

```c
#include <onomondo/softsim/softsim.h>

#include <stddef.h>
#include <stdint.h>

int main(void)
{
	struct ss_context *ctx = ss_new_ctx();
	uint8_t apdu[] = { 0xFF, 0xFF, 0xFF, 0xFF, 0x7F };
	uint8_t rsp[256 + 2];
	size_t len = sizeof(apdu);
	ss_transact(ctx, rsp, sizeof(rsp), apdu, &len); // segfaults here
	return 0;
}
```

### The reproduce before the fix:

```
   LCHAN    DEBUG allocating APDU 0x14d6048c0
   LCHAN    DEBUG ------------------------- transaction begins ------------------------
   LCHAN    DEBUG Rx C-APDU FF-FF FF-FF 7F
   LCHAN    DEBUG Returning rsp_len = 0 bytes after le = 0
   LCHAN    DEBUG Tx R-APDU SW=6882
   LCHAN     INFO Unsuccessful response 6882, restoring backup path.
[1]    20828 segmentation fault  build/src/softsim/softsim
```


### The reproduce after the fix:
```
   LCHAN    DEBUG allocating APDU 0x1576048c0
   LCHAN    DEBUG ------------------------- transaction begins ------------------------
   LCHAN    DEBUG Rx C-APDU FF-FF FF-FF 7F
   LCHAN    DEBUG Returning rsp_len = 0 bytes after le = 0
   LCHAN    DEBUG Tx R-APDU SW=6882
  PROACT    DEBUG proactive sim: inactive
   LCHAN    DEBUG ------------------------- transaction ended -------------------------
   LCHAN    ERROR tossing APDU without lchan
```

---

Thanks for open-sourcing this awesome project, it helps me to develop my ISO7816-3 emulator on STM32. 