### PR TITLE
fix: free the FID record read while resolving an SFI

### DIFF
--- a/src/softsim/uicc/fs_utils.c
+++ b/src/softsim/uicc/fs_utils.c
@@ -68,6 +68,7 @@ size_t ss_fs_utils_find_free_record(const struct ss_list *path)
 		if (record->len == 0) {
 			SS_LOGP(SFS, LERROR, "file (%s) seems to contain zero length record (bad file descriptor?)\n",
 				ss_fs_utils_dump_path(path));
+			ss_buf_free(record);
 			return 0;
 		}
 

--- a/src/softsim/uicc/sfi.c
+++ b/src/softsim/uicc/sfi.c
@@ -131,6 +131,9 @@ int ss_sfi_resolve(const struct ss_list *path, uint8_t sfi)
 	SS_LOGP(SSFI, LDEBUG, "resolved SFI=%02x to FID=%04x using lookup file %s\n", sfi, rc,
 		ss_fs_utils_dump_path(&path_copy));
 leave:
+	/* NULL on every path that jumps here before the read, and ss_buf_free
+	 * tolerates NULL. */
+	ss_buf_free(fid);
 	ss_path_reset(&path_copy);
 	return rc;
 }


### PR DESCRIPTION
ss_sfi_resolve() takes an ss_buf from ss_fs_read_file_record() and returns without freeing it, leaking 18 bytes on every SFI-addressed READ BINARY, UPDATE BINARY, READ RECORD and UPDATE RECORD. The leave: label reset the path copy but not the buffer.

LeakSanitizer reports it on every conformance run that exercises SFI selection.

Also free the record on the zero-length-record error path in ss_fs_utils_find_free_record(), which loses the buffer the same way.