### PR TITLE
fix: verify AUTN MAC before SQN and report incorrect MAC as 9862

### DIFF
--- a/src/softsim/milenage/milenage_usim.c
+++ b/src/softsim/milenage/milenage_usim.c
@@ -69,7 +69,8 @@ static void store_u48be(u8 *out, u64 in)
  * @mr: caller-allocated memory for output data
  * @_rand: RAND = 128-bit random challenge
  * @autn: AUTN = 128-bit authentication token
- * Returns: 0 on success, -1 on failure, or -2 on synchronization failure
+ * Returns: 0 on success, -1 on failure, -2 on synchronization failure, or -3 on
+ * AUTN MAC mismatch
  *
  * See Annex C.2.2 of 3GPP TS 33.102 for the details on how the USIM checks for
  * SQN freshness.
@@ -139,8 +140,7 @@ int milenage_usim_check(const struct milenage_key_data *kd,
 		goto out;
 	}
 
-	/* MAC is valid; now check SQN freshness. */
-	/* Determine IND and SEQ from SQN */
+	/* MAC is valid; now check SQN freshness. Determine IND and SEQ from SQN */
 	rx_sqn64 = load_u48be(rx_sqn);
 	ind = rx_sqn64 & MILENAGE_IND_MASK;
 	rx_seq = rx_sqn64 >> MILENAGE_IND_LEN;

--- a/src/softsim/milenage/milenage_usim.c
+++ b/src/softsim/milenage/milenage_usim.c
@@ -120,6 +120,26 @@ int milenage_usim_check(const struct milenage_key_data *kd,
 		rx_sqn[i] = autn[i] ^ ak[i];
 	wpa_hexdump(MSG_DEBUG, "Milenage: SQN", rx_sqn, 6);
 
+	/* Verify the network authentication code (MAC) BEFORE checking SQN
+	 * freshness. Per 3GPP TS 33.102 §6.3.3 the USIM verifies the MAC first;
+	 * a forged AUTN with a wrong MAC must be rejected as an authentication
+	 * error (-3) and never answered with a resynchronisation token. */
+	amf = autn + 6;
+	wpa_hexdump(MSG_DEBUG, "Milenage: AMF", amf, 2);
+	if (milenage_f1(opc, kd->k, _rand, rx_sqn, amf, mac_a, NULL))
+		goto out;
+
+	wpa_hexdump(MSG_DEBUG, "Milenage: MAC_A", mac_a, 8);
+
+	if (os_memcmp_const(mac_a, autn + 8, 8) != 0) {
+		wpa_printf(MSG_DEBUG, "Milenage: MAC mismatch");
+		wpa_hexdump(MSG_DEBUG, "Milenage: Received MAC_A",
+			    autn + 8, 8);
+		ret = -3;
+		goto out;
+	}
+
+	/* MAC is valid; now check SQN freshness. */
 	/* Determine IND and SEQ from SQN */
 	rx_sqn64 = load_u48be(rx_sqn);
 	ind = rx_sqn64 & MILENAGE_IND_MASK;
@@ -142,20 +162,6 @@ int milenage_usim_check(const struct milenage_key_data *kd,
 
 	/* C.2.2 successful case: SEQ > SEQ_MS(i) */
 	sd->seq[ind] = rx_seq;
-
-	amf = autn + 6;
-	wpa_hexdump(MSG_DEBUG, "Milenage: AMF", amf, 2);
-	if (milenage_f1(opc, kd->k, _rand, rx_sqn, amf, mac_a, NULL))
-		goto out;
-
-	wpa_hexdump(MSG_DEBUG, "Milenage: MAC_A", mac_a, 8);
-
-	if (os_memcmp_const(mac_a, autn + 8, 8) != 0) {
-		wpa_printf(MSG_DEBUG, "Milenage: MAC mismatch");
-		wpa_hexdump(MSG_DEBUG, "Milenage: Received MAC_A",
-			    autn + 8, 8);
-		goto out;
-	}
 
 	ret = 0;
 

--- a/src/softsim/uicc/uicc_auth.c
+++ b/src/softsim/uicc/uicc_auth.c
@@ -305,6 +305,13 @@ static int authenticate_milenage(struct ss_apdu *apdu, enum usim_auth_ctx auth_c
 			memcpy(&apdu->rsp[2], mres.auts, sizeof(mres.auts));
 			apdu->rsp_len = 2 + sizeof(mres.auts);
 			return 0;
+		case -3:
+			/* AUTN MAC verification failed: TS 31.102 7.1.2 /
+			 * TS 102 221 -> SW 9862 "authentication error,
+			 * incorrect MAC". */
+			SS_LOGP(SAUTH, LERROR, "authentication failed: incorrect MAC\n");
+			apdu->sw = SS_SW_APP_ERR_AUTH_ERR_APP_SPECIFIC;
+			return 0;
 		default:
 			SS_LOGP(SAUTH, LERROR, "authentication failed\n");
 			break;

--- a/src/softsim/uicc/uicc_auth.c
+++ b/src/softsim/uicc/uicc_auth.c
@@ -311,7 +311,11 @@ static int authenticate_milenage(struct ss_apdu *apdu, enum usim_auth_ctx auth_c
 			 * incorrect MAC". */
 			SS_LOGP(SAUTH, LERROR, "authentication failed: incorrect MAC\n");
 			apdu->sw = SS_SW_APP_ERR_AUTH_ERR_APP_SPECIFIC;
-			return 0;
+			/* Leave via out_err so RES/CK/IK -- already derived
+			 * before the MAC check -- are scrubbed. out_err
+			 * returns -1, but the dispatcher only substitutes its
+			 * own SW when the handler left apdu->sw at 0. */
+			goto out_err;
 		default:
 			SS_LOGP(SAUTH, LERROR, "authentication failed\n");
 			break;


### PR DESCRIPTION
TS 33.102 §6.3.3 verifies the MAC first. The f1/MAC compare now precedes the SQN freshness checks; a mismatch answers SW 9862 (TS 31.102 §7.1.2) with no data and no longer advances SEQ_MS. The second commit scrubs RES/CK/IK on that path, since they are derived before the MAC check.

Fixes SOFTSIM-165