### PR TITLE
fix: report failure from ss_fs_utils_create_record_file

### DIFF
--- a/src/softsim/uicc/fs_utils.c
+++ b/src/softsim/uicc/fs_utils.c
@@ -183,7 +183,7 @@ int ss_fs_utils_create_record_file(const struct ss_list *path, uint32_t fid, uin
 leave:
 	ss_buf_free(fcp);
 	ss_path_reset(&path_copy);
-	return 0;
+	return rc;
 }
 
 /*! Obtain a deep copy of a path.

--- a/tests/storage/storage_test.c
+++ b/tests/storage/storage_test.c
@@ -10,6 +10,9 @@
 #include <string.h>
 #include <assert.h>
 #include <onomondo/softsim/storage.h>
+#include <onomondo/softsim/list.h>
+#include "src/softsim/uicc/fs.h"
+#include "src/softsim/uicc/fs_utils.h"
 
 void test_storage_path_default(void)
 {
@@ -100,6 +103,26 @@ void test_storage_path_empty_string(void)
 	printf("Empty path rejection test passed\n");
 }
 
+/* ss_fs_utils_create_record_file() used to return 0 unconditionally, so a
+ * caller could not tell that the internal lookup file it asked for was never
+ * created. Point the storage root at a directory that does not exist, which
+ * makes the create fail in the storage layer, and require that the failure
+ * reaches the caller. */
+void test_create_record_file_reports_failure(void)
+{
+	struct ss_list path;
+	int rc;
+
+	rc = ss_storage_set_path("/nonexistent-storage-root-for-test/files");
+	assert(rc == 0);
+
+	ss_list_init(&path);
+	rc = ss_fs_utils_create_record_file(&path, 0x5F100001, 2, 0x1f);
+	assert(rc < 0);
+	ss_path_reset(&path);
+	printf("Create record file failure propagation test passed\n");
+}
+
 int main(void)
 {
 	test_storage_path_default();
@@ -110,5 +133,6 @@ int main(void)
 	test_storage_path_multiple_sets();
 	test_storage_path_special_chars();
 	test_storage_path_empty_string();
+	test_create_record_file_reports_failure();
 	return 0;
 }

--- a/tests/storage/storage_test.ok
+++ b/tests/storage/storage_test.ok
@@ -7,3 +7,4 @@ Max length path test passed (length: 98)
 Multiple path changes test passed
 Special characters in path test passed
 Empty path rejection test passed
+Create record file failure propagation test passed


### PR DESCRIPTION
`ss_fs_utils_create_record_file()` computed `rc` on every path and then returned a literal `0` from
its `leave:` label, so a failure to create an internal lookup file was reported to the caller as
success — a one-word divergence from the contract in its own header.

Both callers already handle the failure; they just never saw it. `ss_uicc_admin_cmd_create_file()`
deletes the file it just created and answers with a memory-problem status word, so without this fix a
CREATE FILE could report success while leaving the SFI lookup file absent, and later SFI-based access
to that file would not resolve. So returning `rc` activates existing handling rather than changing
any contract.

The issue title says "memory leak", which is not what the code does — `fcp` and `path_copy` are both
released at `leave:` on every path. The defect is the swallowed error code, which is the worse of the
two: a caller acting on a false success beats a bounded leak.

Covered by a case in `storage_test` that points the storage root at a directory which does not exist;
it fails against the previous code.

Closes #111
