### PR TITLE
fix: check the SEARCH RECORD data length before reading the search mode

### DIFF
--- a/src/softsim/uicc/uicc_file_ops.c
+++ b/src/softsim/uicc/uicc_file_ops.c
@@ -600,14 +600,14 @@ int ss_uicc_file_ops_cmd_search_record(struct ss_apdu *apdu)
 
 	switch (search_mode) {
 	case SEARCH_ENHANCED:
-		/* See also ETSI TS 102 221, table Table 11.13 */
-		enchanced_search_mode = apdu->cmd[0];
-
 		SS_LOGP(SFILE, LDEBUG, "search mode: \"enhanced search\"\n");
 		if (apdu->lc < 3) {
 			SS_LOGP(SFILE, LERROR, "no search string!\n");
 			return SS_SW_ERR_CHECKING_WRONG_P1_P2;
 		}
+
+		/* See also ETSI TS 102 221, table Table 11.13 */
+		enchanced_search_mode = apdu->cmd[0];
 
 		search_string = apdu->cmd + 2;
 		search_string_len = apdu->lc - 2;


### PR DESCRIPTION
The enhanced-search arm of SEARCH RECORD read `apdu->cmd[0]` before checking that the command carries
the three data bytes that mode requires, so the read happened even for `Lc = 0` — which is reachable,
since SEARCH RECORD is `SS_COMMAND_CASE_4` and the dispatcher sets `apdu->lc = apdu->hdr.p3`. Moving
the read below the check makes this arm match the simple-search arm right below it.

**It is not the out-of-bounds read the report describes.** `apdu->cmd` is a fixed 256-byte member of
`struct ss_apdu`, so the read is in bounds, and the length check on the next line discards the value
and answers 6B00 either way. No behaviour change — which is also why no test can tell the two
orderings apart.

Worth stating where that byte comes from, since it isn't what the report assumes: on the terminal
path `apdu->cmd` is zeroed in `ss_apdu_new()`, but on the RFM path `ss_uicc_remote_cmd_receive()`
hands `ss_transact()` the whole remaining command chain, so `cmd[0]` is the first byte of the *next
chained command*. Discarded either way — but what this buys is that the arm no longer depends on how
the caller happened to fill a buffer the command never wrote to.

Closes #108
