### PR TITLE
fix: enforce the MF check in ss_access_check_command() at runtime

### DIFF
--- a/src/softsim/uicc/access.c
+++ b/src/softsim/uicc/access.c
@@ -246,8 +246,14 @@ bool ss_access_check_command(struct ss_apdu *apdu, enum ss_access_intention inte
 	struct ss_file *mf = ss_get_file_from_path(apdu->lchan->fs_path.next->next);
 	/* If a situation ever comes up where using a path that does not start at the
 	 * MF is valid, we can still consider loading the MF as it is done above --
-	 * but until there is a legitimate use case, it is most likely a bug. */
-	assert(mf->fid == 0x3f00);
+	 * but until there is a legitimate use case, it is most likely a bug.
+	 *
+	 * Not an assert: -DNDEBUG would strip it, and the lifecycle byte read below
+	 * would then decide access control based on an unrelated file. */
+	if (!mf || mf->fid != 0x3f00) {
+		SS_LOGP(SACCESS, LERROR, "path does not start at the MF, rejecting all access.\n");
+		return false;
+	}
 
 	struct ber_tlv_ie *lcsi_do = ss_btlv_get_ie_minlen(mf->fcp_decoded, TS_102_221_IEI_FCP_LIFE_CYCLE_ST, 1);
 	if (lcsi_do == NULL || lcsi_do->value->data[0] == 0) {

--- a/src/softsim/uicc/access.c
+++ b/src/softsim/uicc/access.c
@@ -251,7 +251,7 @@ bool ss_access_check_command(struct ss_apdu *apdu, enum ss_access_intention inte
 	 * Not an assert: -DNDEBUG would strip it, and the lifecycle byte read below
 	 * would then decide access control based on an unrelated file. */
 	if (!mf || mf->fid != 0x3f00) {
-		SS_LOGP(SACCESS, LERROR, "path does not start at the MF, rejecting all access.\n");
+		SS_LOGP(SACCESS, LERROR, "Path does not start at the MF, rejecting all access.\n");
 		return false;
 	}
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -4,6 +4,7 @@
 # Enable testing for current directory and below.
 enable_testing()
 
+add_subdirectory(access)
 add_subdirectory(aes)
 add_subdirectory(apdu)
 add_subdirectory(app_transact)

--- a/tests/access/CMakeLists.txt
+++ b/tests/access/CMakeLists.txt
@@ -1,0 +1,11 @@
+# Copyright (c) 2026 Onomondo ApS. All rights reserved.
+# SPDX-License-Identifier: GPL-3.0-only
+
+add_executable(access_test access_test.c)
+
+include_directories(${PROJECT_SOURCE_DIR})
+include_directories(${PROJECT_SOURCE_DIR}/include)
+
+target_link_libraries(access_test uicc storage)
+
+add_test(NAME access_test COMMAND sh -c "$<TARGET_FILE:access_test> > access_test.out")

--- a/tests/access/CMakeLists.txt
+++ b/tests/access/CMakeLists.txt
@@ -9,3 +9,11 @@ include_directories(${PROJECT_SOURCE_DIR}/include)
 target_link_libraries(access_test uicc storage)
 
 add_test(NAME access_test COMMAND sh -c "$<TARGET_FILE:access_test> > access_test.out")
+
+add_test(NAME access_test_compare
+		 COMMAND ${CMAKE_COMMAND} -E compare_files --ignore-eol
+				 ${CMAKE_CURRENT_BINARY_DIR}/access_test.out
+				 ${CMAKE_CURRENT_SOURCE_DIR}/access_test.ok
+)
+
+set_tests_properties(access_test_compare PROPERTIES DEPENDS access_test)

--- a/tests/access/access_test.c
+++ b/tests/access/access_test.c
@@ -48,10 +48,11 @@ static int non_mf_root_denied_test(void)
 	ss_btlv_free(file.fcp_decoded);
 
 	if (granted) {
-		printf("FAIL: access granted on a path not rooted at the MF\n");
+		/* stderr, so ctest shows it: stdout goes to access_test.out */
+		fprintf(stderr, "FAIL: access granted on a path not rooted at the MF\n");
 		return 1;
 	}
-	printf("Access check on a path not rooted at the MF is denied\n");
+	printf("Non-MF root path rejection test passed\n");
 	return 0;
 }
 

--- a/tests/access/access_test.c
+++ b/tests/access/access_test.c
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2026 Onomondo ApS. All rights reserved.
+ *
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <onomondo/softsim/file.h>
+#include <onomondo/softsim/list.h>
+#include <onomondo/softsim/log.h>
+#include <onomondo/softsim/mem.h>
+#include "src/softsim/uicc/access.h"
+#include "src/softsim/uicc/apdu.h"
+#include "src/softsim/uicc/btlv.h"
+#include "src/softsim/uicc/fcp.h"
+
+extern uint32_t ss_log_mask;
+
+/* A path whose first element is not the MF must be denied. While this was an
+ * assert(), a -DNDEBUG build took the lifecycle byte of that unrelated file
+ * instead and granted every access when it read < 4 (creation state).
+ *
+ * Checked with an if() rather than assert() so the check survives -DNDEBUG,
+ * which is the build this guards. */
+static int non_mf_root_denied_test(void)
+{
+	struct ss_lchan lchan;
+	struct ss_apdu apdu;
+	struct ss_file file;
+	uint8_t lifecycle = 0x01;
+
+	memset(&lchan, 0, sizeof(lchan));
+	memset(&apdu, 0, sizeof(apdu));
+	memset(&file, 0, sizeof(file));
+
+	apdu.lchan = &lchan;
+	ss_list_init(&lchan.fs_path);
+
+	file.fid = 0x7f10; /* DF.TELECOM, not the MF */
+	file.fcp_decoded = SS_ALLOC(struct ss_list);
+	ss_list_init(file.fcp_decoded);
+	ss_btlv_new_ie(file.fcp_decoded, "life_cycle_status", TS_102_221_IEI_FCP_LIFE_CYCLE_ST, 1, &lifecycle);
+	ss_list_put(&lchan.fs_path, &file.list);
+
+	bool granted = ss_access_check_command(&apdu, SS_ACCESS_INTENTION_EF_READ);
+
+	ss_btlv_free(file.fcp_decoded);
+
+	if (granted) {
+		printf("FAIL: access granted on a path not rooted at the MF\n");
+		return 1;
+	}
+	printf("Access check on a path not rooted at the MF is denied\n");
+	return 0;
+}
+
+int main(void)
+{
+	ss_log_mask = 0;
+	return non_mf_root_denied_test();
+}

--- a/tests/access/access_test.ok
+++ b/tests/access/access_test.ok
@@ -1,0 +1,1 @@
+Non-MF root path rejection test passed


### PR DESCRIPTION
`assert()` is compiled out wherever `NDEBUG` is defined, which CMake does for
`-DCMAKE_BUILD_TYPE=Release`. So in a release build nothing checked that the path starts at the
MF. Replaced with a runtime check that logs and denies.

The consequence isn't the crash the report assumes: execution continues into the lifecycle read
below, and a byte < 4 there means "card in creation state" and returns `true` — all access
control lifted. So this fails closed.

I found no input that reaches it today; the guard is here because the invariant rests on the
profile tree rather than on code. (`!mf->fcp_decoded` isn't needed — `ss_btlv_get_ie()`
NULL-guards its list, so the `lcsi_do == NULL` branch below already denies.)

`tests/access/access_test.c` covers it with an `if` rather than `assert()`, so the check survives
the `-DNDEBUG` build it exists for.

Closes #107
