### PR TITLE
fix: guard NULL lifecycle status IE in active ACTIVATE FILE

### DIFF
--- a/src/softsim/uicc/uicc_admin.c
+++ b/src/softsim/uicc/uicc_admin.c
@@ -409,7 +409,8 @@ int ss_uicc_admin_cmd_activate_file(struct ss_apdu *apdu)
 	fcp_decoded_lifecycle = ss_btlv_get_ie_minlen(selected_file->fcp_decoded, TS_102_221_IEI_FCP_LIFE_CYCLE_ST, 1);
 	if (!fcp_decoded_lifecycle) {
 		SS_LOGP(SADMIN, LERROR, "missing lifecycle status IE -- cannot activate file\n");
-		return SS_SW_ERR_EXEC_MEMORY_PROBLEM;
+		/* TS 102 221 §10.2.2 - Status words of the commands */
+		return SS_SW_ERR_EXEC_NO_INFO_NV_UNCHANGED;
 	}
 	fcp_decoded_lifecycle->value->data[0] = 0x05;
 

--- a/src/softsim/uicc/uicc_admin.c
+++ b/src/softsim/uicc/uicc_admin.c
@@ -407,6 +407,10 @@ int ss_uicc_admin_cmd_activate_file(struct ss_apdu *apdu)
 	struct ber_tlv_ie *fcp_decoded_lifecycle;
 	struct ss_file *selected_file = ss_get_file_from_path(&apdu->lchan->fs_path);
 	fcp_decoded_lifecycle = ss_btlv_get_ie_minlen(selected_file->fcp_decoded, TS_102_221_IEI_FCP_LIFE_CYCLE_ST, 1);
+	if (!fcp_decoded_lifecycle) {
+		SS_LOGP(SADMIN, LERROR, "missing lifecycle status IE -- cannot activate file\n");
+		return SS_SW_ERR_EXEC_MEMORY_PROBLEM;
+	}
 	fcp_decoded_lifecycle->value->data[0] = 0x05;
 
 	/* Store encoded FCP again */


### PR DESCRIPTION
ss_btlv_get_ie_minlen() can return NULL when the selected file's FCP lacks
the lifecycle status IE. Guard against NULL fcp_decoded_lifecycle