### PR TITLE
fix: report an unknown class as 6e00 instead of 6d00

### DIFF
--- a/src/softsim/uicc/softsim.c
+++ b/src/softsim/uicc/softsim.c
@@ -347,9 +347,9 @@ static int apdu_transact(struct ss_context *ctx, struct ss_apdu *apdu)
 				else
 					apdu->sw = rc;
 			}
-		} else {
-			apdu->sw = SS_SW_ERR_CHECKING_INS_INVALID;
 		}
+		/* No else: ss_command_match() already set 6e00 or 6d00, and it can tell
+		 * an unknown class from an unknown instruction. */
 	}
 
 out:

--- a/tests/init/init_test.c
+++ b/tests/init/init_test.c
@@ -62,11 +62,42 @@ const char *apdus[] = {
 	/* perform authentication */
 };
 
+/* An unknown class must be answered 6e00, an unknown instruction 6d00.
+ * TS 102 221 clause 10.2.1.5.0; TS 31.122 clause 6.7.2.1 steps r) and t). */
+static void unknown_class_test(struct ss_context *ctx)
+{
+	const struct {
+		uint8_t apdu[5];
+		uint16_t sw;
+	} cases[] = {
+		{ { 0x30, 0xc0, 0x00, 0x00, 0x00 }, 0x6e00 }, /* class '30' */
+		{ { 0xa0, 0xf2, 0x00, 0x00, 0x00 }, 0x6e00 }, /* GSM class 'A0' */
+		{ { 0x00, 0x6f, 0x00, 0x00, 0x00 }, 0x6d00 }, /* known class, unknown INS */
+	};
+	uint8_t resp[300];
+
+	for (size_t i = 0; i < SS_ARRAY_SIZE(cases); i++) {
+		uint8_t cmd[sizeof(cases[i].apdu)];
+		size_t cmd_len = sizeof(cmd);
+		size_t resp_len;
+
+		memcpy(cmd, cases[i].apdu, sizeof(cmd));
+		memset(resp, 0, sizeof(resp));
+		resp_len = ss_transact(ctx, resp, sizeof(resp), cmd, &cmd_len);
+
+		assert(resp_len == 2);
+		assert(((resp[0] << 8) | resp[1]) == cases[i].sw);
+	}
+}
+
 int main(void)
 {
 	struct ss_context *ctx;
 
 	ctx = ss_new_ctx();
+	ss_reset(ctx);
+
+	unknown_class_test(ctx);
 	ss_reset(ctx);
 
 	size_t cmd_len = 0;


### PR DESCRIPTION
ss_command_match() already distinguishes an unknown class from an unknown instruction and sets 6e00 or 6d00 accordingly, but apdu_transact() overwrote it with 6d00 for every NULL return, so an unsupported class byte was reported as an unsupported instruction.

TS 102 221 clause 10.2.1.5.0 defines '6E00' class not supported; TS 31.122 clause 6.7.2.1 step t) requires it for class '30', and TS 31.101 clause 8.1.1 step c) for the GSM class 'A0'. Both were answered 6d00.

Drop the overwrite: apdu->sw is zero on entry and ss_command_match() sets it on every failure path, so the else branch only destroyed the better diagnosis.