### PR TITLE
fix: bound the profile parser

### DIFF
--- a/include/onomondo/utils/ss_profile.h
+++ b/include/onomondo/utils/ss_profile.h
@@ -66,9 +66,10 @@ struct ss_profile {
  *  This decoder is made specifically to fit the Onomondo SoftSIM
  *  CLI tools decrypted output format.
  *  
- *  \param[in] input_string a pointer to the input data source of the profile.
  *  \param[in] len the length of the profile string.
- *  \param[in] profile a pointer to the receiving profile struct.
+ *  \param[in] input_string a pointer to the input data source of the profile,
+ *             at least len characters long.
+ *  \param[out] profile a pointer to the receiving profile struct.
  *  \returns return 0 if valid profile is decoded. error code otherwise.
  */
 uint8_t ss_profile_from_string(uint16_t len, const char *input_string, struct ss_profile *profile);

--- a/include/onomondo/utils/ss_profile.h
+++ b/include/onomondo/utils/ss_profile.h
@@ -71,4 +71,4 @@ struct ss_profile {
  *  \param[in] profile a pointer to the receiving profile struct.
  *  \returns return 0 if valid profile is decoded. error code otherwise.
  */
-uint8_t ss_profile_from_string(uint16_t len, const char input_string[len], struct ss_profile *profile);
+uint8_t ss_profile_from_string(uint16_t len, const char *input_string, struct ss_profile *profile);

--- a/tests/utils/profile_decode_test.c
+++ b/tests/utils/profile_decode_test.c
@@ -208,11 +208,37 @@ static void decode_softsim_profile_test_err_length_no_overflow()
 	printf("Profile decode return value: %d\n", rc);
 }
 
+/* An input too short to hold one TAG(2) + LEN(2) record header is rejected without
+ * reading it. Trailing characters that cannot start a header are ignored, so a
+ * profile arriving with a line ending decodes. */
+static void decode_softsim_profile_test_short_input()
+{
+	char with_line_ending[256];
+	struct ss_profile profile = { 0 };
+	uint8_t rc;
+
+	printf("TEST: Decode a decrypted Onomondo SoftSIM profile that is too short\n");
+
+	rc = ss_profile_from_string(0, "", &profile);
+	printf("Profile decode return value: %d\n", rc);
+	assert(rc != 0);
+
+	rc = ss_profile_from_string(2, "b0", &profile);
+	printf("Profile decode return value: %d\n", rc);
+	assert(rc != 0);
+
+	snprintf(with_line_ending, sizeof(with_line_ending), "%s\r\n", decrypted_profile_ok);
+	rc = ss_profile_from_string(strlen(with_line_ending), with_line_ending, &profile);
+	printf("Profile decode return value: %d\n", rc);
+	assert(rc == 0);
+}
+
 int main(int argc, char **argv)
 {
 	decode_softsim_profile_test_ok();
 	decode_softsim_profile_test_err_imsi();
 	decode_softsim_profile_test_err_bad_length_encoding();
 	decode_softsim_profile_test_err_length_no_overflow();
+	decode_softsim_profile_test_short_input();
 	return 0;
 }

--- a/tests/utils/profile_decode_test.c
+++ b/tests/utils/profile_decode_test.c
@@ -209,8 +209,9 @@ static void decode_softsim_profile_test_err_length_no_overflow()
 }
 
 /* An input too short to hold one TAG(2) + LEN(2) record header is rejected without
- * reading it. Trailing characters that cannot start a header are ignored, so a
- * profile arriving with a line ending decodes. */
+ * reading it. Fewer than four trailing characters are ignored regardless of their
+ * content, so a profile arriving with a line ending decodes; four or more are
+ * parsed as a record header. */
 static void decode_softsim_profile_test_short_input()
 {
 	char with_line_ending[256];

--- a/tests/utils/profile_decode_test.ok
+++ b/tests/utils/profile_decode_test.ok
@@ -23,3 +23,7 @@ TEST: Decode a decrypted Onomondo SoftSIM profile with expected decode error
 Profile decode return value: 13
 TEST: Decode a decrypted Onomondo SoftSIM profile with expected decode error
 Profile decode return value: 1
+TEST: Decode a decrypted Onomondo SoftSIM profile that is too short
+Profile decode return value: 1
+Profile decode return value: 1
+Profile decode return value: 0

--- a/utils/ss_profile.c
+++ b/utils/ss_profile.c
@@ -14,6 +14,12 @@ static void ss_hex_string_to_bytes(const uint8_t *hex, size_t hex_len, uint8_t b
 
 uint8_t ss_profile_from_string(uint16_t len, const char *input_string, struct ss_profile *profile)
 {
+	/* TAG(2) + LEN(2): the loop bound keeps the header inside the buffer, and the
+	 * data_end check below bounds the data field. Rejected before anything is
+	 * written into the output struct. */
+	if (len < 4)
+		return 1;
+
 	/* Stucture (a004): [TAR[3] | MSL | KIC_IND | KID_IND | KIC[32] | KID[32] | */
 	static const char a004_header[] = "b00011060101";
 	const size_t A004_RECORD_SIZE = A004_HEADER_SIZE + KEY_SIZE + KEY_SIZE;
@@ -29,11 +35,6 @@ uint8_t ss_profile_from_string(uint16_t len, const char *input_string, struct ss
 
 	size_t pos = 0, data_end = 0, data_start = 0, next_pos = 0;
 	uint8_t tag = 0, data_len = 0;
-
-	/* TAG(2) + LEN(2): the loop bound keeps the header inside the buffer, and the
-	 * data_end check below bounds the data field. */
-	if (len < 4)
-		return 1;
 
 	while (pos + 4 <= len) {
 		data_start = pos + 4;

--- a/utils/ss_profile.c
+++ b/utils/ss_profile.c
@@ -10,7 +10,7 @@
 #include "onomondo/utils/ss_profile.h"
 
 static uint8_t ss_hex_to_uint8(const char *hex);
-static void ss_hex_string_to_bytes(const uint8_t *hex, size_t hex_len, uint8_t bytes[hex_len / 2]);
+static void ss_hex_string_to_bytes(const uint8_t *hex, size_t hex_len, uint8_t *bytes);
 
 uint8_t ss_profile_from_string(uint16_t len, const char *input_string, struct ss_profile *profile)
 {
@@ -152,10 +152,10 @@ static uint8_t ss_hex_to_uint8(const char *hex)
 /** Hex string to bytes converter
  *  \param[in] hex a pointer to the hex string
  *  \param[in] hex_len the size of the string
- *  \param[inout] bytes the byte array to store the result in */
-static void ss_hex_string_to_bytes(const uint8_t *hex, size_t hex_len, uint8_t bytes[hex_len / 2])
+ *  \param[out] bytes the byte array to store the result in, hex_len / 2 bytes long */
+static void ss_hex_string_to_bytes(const uint8_t *hex, size_t hex_len, uint8_t *bytes)
 {
-	int i;
+	size_t i;
 
 	for (i = 0; i < hex_len / 2; i++) {
 		bytes[i] = ss_hex_to_uint8((char *)&hex[i * 2]);

--- a/utils/ss_profile.c
+++ b/utils/ss_profile.c
@@ -12,7 +12,7 @@
 static uint8_t ss_hex_to_uint8(const char *hex);
 static void ss_hex_string_to_bytes(const uint8_t *hex, size_t hex_len, uint8_t bytes[hex_len / 2]);
 
-uint8_t ss_profile_from_string(uint16_t len, const char input_string[len], struct ss_profile *profile)
+uint8_t ss_profile_from_string(uint16_t len, const char *input_string, struct ss_profile *profile)
 {
 	/* Stucture (a004): [TAR[3] | MSL | KIC_IND | KID_IND | KIC[32] | KID[32] | */
 	static const char a004_header[] = "b00011060101";
@@ -30,7 +30,12 @@ uint8_t ss_profile_from_string(uint16_t len, const char input_string[len], struc
 	size_t pos = 0, data_end = 0, data_start = 0, next_pos = 0;
 	uint8_t tag = 0, data_len = 0;
 
-	while (pos < len - 2) {
+	/* TAG(2) + LEN(2): the loop bound keeps the header inside the buffer, and the
+	 * data_end check below bounds the data field. */
+	if (len < 4)
+		return 1;
+
+	while (pos + 4 <= len) {
 		data_start = pos + 4;
 		tag = ss_hex_to_uint8((char *)&input_string[pos]);
 		data_len = ss_hex_to_uint8((char *)&input_string[pos + 2]);


### PR DESCRIPTION
Two out-of-bounds reads in the profile parser, reachable from a corrupted or truncated provisioning
blob: a `uint16_t` length underflow that entered the parse loop with nothing to read, and a record
header read one byte past the end.

To sanction: a blob too short to hold one record now returns 1. A trailing line ending is still
tolerated on purpose — such a profile decodes today and must keep decoding.

Details and the load-bearing test are in the commit message.
