### PR TITLE
fix: provision the whole profile, or none of it

### DIFF
--- a/include/onomondo/utils/ss_profile.h
+++ b/include/onomondo/utils/ss_profile.h
@@ -100,6 +100,12 @@ struct ss_profile {
  */
 uint8_t ss_profile_from_string(uint16_t len, const char *input_string, struct ss_profile *profile);
 
+/** Clear a decoded profile before its memory is released.
+ *  ss_profile_from_string() already clears on error; call this once the profile
+ *  has been consumed, so no key material outlives its use.
+ *  \param[out] profile the profile to clear. */
+void ss_profile_wipe(struct ss_profile *profile);
+
 /** Compute the CRC32 a profile's CRC record must carry.
  *
  *  CRC-32/ISO-HDLC, as used by zlib: reflected polynomial 0xedb88320, initial and

--- a/include/onomondo/utils/ss_profile.h
+++ b/include/onomondo/utils/ss_profile.h
@@ -91,7 +91,8 @@ struct ss_profile {
  *              key material behind.
  *  \returns return 0 if valid profile is decoded. error code otherwise: 1 for a
  *  malformed blob, 10..17 for a tag of the wrong length, 18 for a CRC record of
- *  the wrong length and 19 for a CRC that does not match the profile.
+ *  the wrong length, 19 for a CRC that does not match the profile and 20 for a
+ *  PIN, PUK or ADM value no PIN code file record can hold.
  */
 uint8_t ss_profile_from_string(uint16_t len, const char *input_string, struct ss_profile *profile);
 

--- a/include/onomondo/utils/ss_profile.h
+++ b/include/onomondo/utils/ss_profile.h
@@ -54,6 +54,10 @@ struct ss_profile {
 	uint8_t k[16];
 	uint8_t kid[16];
 	uint8_t kic[16];
+	/* Set when the profile carried a PIN, PUK or ADM value. The PIN code file
+	 * holds state the card maintains, so it is written only for a profile that
+	 * has something to put in it. */
+	uint8_t pin_present;
 };
 
 /* Onomondo SoftSIM Profile Decoder

--- a/tests/utils/CMakeLists.txt
+++ b/tests/utils/CMakeLists.txt
@@ -37,13 +37,25 @@ if(TARGET utils)
 
 	add_test(NAME profile_provision_test COMMAND sh -c "$<TARGET_FILE:profile_provision_test> > ${CMAKE_CURRENT_BINARY_DIR}/profile_provision_test.out")
 
-	# Ensure the test runs from the project root so relative storage-path './files'
-	# resolves to the repository 'files' directory (where 3f00.def lives). This
-	# avoids needing embedded static files or runtime environment changes for
-	# tests that read the host filesystem.
-	set_tests_properties(profile_provision_test PROPERTIES WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+	# This test provisions into the storage tree, and the storage path './files'
+	# resolves against the working directory. Run it against a snapshot taken at
+	# configure time, as tests/key_scrub does, so a run rewrites keys in the build
+	# directory rather than in the tracked files/.
+	file(COPY ${CMAKE_SOURCE_DIR}/files DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/pristine)
 
-	add_test(NAME profile_provision__test_compare
+	# Refreshed before each run, so repeated ctest invocations start from the same
+	# tree and the test does not have to undo its own writes.
+	add_test(NAME profile_provision_test_setup
+		COMMAND ${CMAKE_COMMAND} -E copy_directory
+			${CMAKE_CURRENT_BINARY_DIR}/pristine/files
+			${CMAKE_CURRENT_BINARY_DIR}/files
+	)
+	set_tests_properties(profile_provision_test_setup PROPERTIES FIXTURES_SETUP profile_provision_files)
+	set_tests_properties(profile_provision_test PROPERTIES
+		FIXTURES_REQUIRED profile_provision_files
+		WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+
+	add_test(NAME profile_provision_test_compare
 		COMMAND ${CMAKE_COMMAND} -E compare_files --ignore-eol
 			${CMAKE_CURRENT_BINARY_DIR}/profile_provision_test.out
 			${CMAKE_CURRENT_SOURCE_DIR}/profile_provision_test.ok

--- a/tests/utils/profile_decode_test.c
+++ b/tests/utils/profile_decode_test.c
@@ -356,6 +356,119 @@ static void decode_softsim_profile_test_err_scrubs()
 	printf("Profile struct cleared\n");
 }
 
+/* The six tags every profile the provisioner accepts must carry, see
+ * decode_softsim_profile_test_ok. */
+// clang-format off
+#define REQUIRED_TAGS \
+	"01" "12" "080910101032540636" \
+	"02" "14" "98001032547698103214" \
+	"03" "20" "00000000000000000000000000000000" \
+	"04" "20" "000102030405060708090A0B0C0D0E0F" \
+	"05" "20" "000102030405060708090A0B0C0D0E0F" \
+	"06" "20" "000102030405060708090A0B0C0D0E0F"
+// clang-format on
+
+static void check_pin_field(const struct ss_profile *profile, const char *what, size_t record, size_t offset,
+			    const char *expect)
+{
+	const uint8_t *field = &profile->_3F00_A003[record * A003_RECORD_SIZE + offset];
+
+	printf("%s: %.*s\n", what, PIN_SIZE, field);
+	assert(memcmp(field, expect, PIN_SIZE) == 0);
+}
+
+/* A value the PIN code file cannot hold is refused, so a card is never left on
+ * the shipped default while the profile says the value was rotated. The struct
+ * is cleared with it, as on every other error return. */
+static void check_pin_refused(const char *what, const char *profile_string)
+{
+	struct ss_profile profile = { 0 };
+	uint8_t zero[sizeof(struct ss_profile)] = { 0 };
+	uint8_t rc;
+
+	printf("TEST: Decode a decrypted Onomondo SoftSIM profile whose %s cannot be stored\n", what);
+	rc = ss_profile_from_string(strlen(profile_string), profile_string, &profile);
+	printf("Profile decode return value: %d\n", rc);
+	assert(rc == 20);
+	assert(memcmp(&profile, zero, sizeof(profile)) == 0);
+	printf("Profile struct cleared\n");
+}
+
+/* A profile carries a PIN as the hex encoded ASCII of its characters, so up to 8
+ * characters arrive as the 16 the record holds. A 16 character ADM arrives as 32
+ * and fits only because it is itself hex, naming the 8 bytes a VERIFY PIN can
+ * carry (TS 102 221 clause 11.1.9.3). */
+static void decode_softsim_profile_test_pins()
+{
+	// clang-format off
+	static const char *profile_pins =
+		REQUIRED_TAGS
+		"08" "08" "36383638"                          /* PIN 6868 */
+		"0b" "10" "3739373937393739"                  /* PUK 79797979 */
+		"0a" "20" "38303334323730323533313133383634"; /* ADM 8034270253113864 */
+	/* An ADM that is not hex cannot name 8 bytes. */
+	static const char *profile_adm_not_hex =
+		REQUIRED_TAGS
+		"0a" "20" "414143434545474749494b4b4d4d4f4f"; /* ADM AACCEEGGIIKKMMOO */
+	static const char *profile_pin_padded =
+		REQUIRED_TAGS
+		"08" "08" "35363738";                         /* PIN 5678 */
+	static const char *profile_pin_short =
+		REQUIRED_TAGS
+		"08" "04" "3132";                             /* PIN 12, under the four digit minimum */
+	/* The record is a hex string, so a character outside it names no byte. */
+	static const char *profile_pin_not_hex =
+		REQUIRED_TAGS
+		"08" "08" "3132zzzz";
+	// clang-format on
+	struct ss_profile profile = { 0 };
+	uint8_t rc;
+
+	printf("TEST: Decode a decrypted Onomondo SoftSIM profile carrying PIN, PUK and ADM\n");
+
+	rc = ss_profile_from_string(strlen(profile_pins), profile_pins, &profile);
+	printf("Profile decode return value: %d\n", rc);
+	assert(rc == 0);
+	check_pin_field(&profile, "PIN1", 0, PIN_OFFSET, "36383638ffffffff");
+	check_pin_field(&profile, "PUK1", 0, PUK_OFFSET, "3739373937393739");
+	check_pin_field(&profile, "PUK2", 1, PUK_OFFSET, "3739373937393739");
+	check_pin_field(&profile, "ADM ", 2, PIN_OFFSET, "8034270253113864");
+
+	printf("TEST: Decode a decrypted Onomondo SoftSIM profile with a PIN shorter than the field\n");
+
+	memset(&profile, 0, sizeof(profile));
+	rc = ss_profile_from_string(strlen(profile_pin_padded), profile_pin_padded, &profile);
+	printf("Profile decode return value: %d\n", rc);
+	assert(rc == 0);
+	check_pin_field(&profile, "PIN1", 0, PIN_OFFSET, "35363738ffffffff");
+
+	check_pin_refused("ADM", profile_adm_not_hex);
+	check_pin_refused("PIN", profile_pin_short);
+	check_pin_refused("PIN", profile_pin_not_hex);
+}
+
+/* Deciding which tags a profile must carry belongs to whoever consumes it: the
+ * provisioner refuses an incomplete profile, the decoder reports what it found.
+ * Keep it that way -- the profile source emits tags only for the fields it has. */
+static void decode_softsim_profile_test_partial_is_not_an_error()
+{
+	// clang-format off
+	static const char *profile_no_keys =
+		"01" "12" "080910101032540636"
+		"02" "14" "98001032547698103214"
+		"03" "20" "00000000000000000000000000000000"
+		"04" "20" "000102030405060708090A0B0C0D0E0F";
+	// clang-format on
+	struct ss_profile profile = { 0 };
+	uint8_t rc;
+
+	printf("TEST: Decode a decrypted Onomondo SoftSIM profile that carries only some tags\n");
+
+	rc = ss_profile_from_string(strlen(profile_no_keys), profile_no_keys, &profile);
+	printf("Profile decode return value: %d\n", rc);
+	assert(rc == 0);
+}
+
 int main(int argc, char **argv)
 {
 	decode_softsim_profile_test_ok();
@@ -365,5 +478,7 @@ int main(int argc, char **argv)
 	decode_softsim_profile_test_short_input();
 	decode_softsim_profile_test_crc();
 	decode_softsim_profile_test_err_scrubs();
+	decode_softsim_profile_test_partial_is_not_an_error();
+	decode_softsim_profile_test_pins();
 	return 0;
 }

--- a/tests/utils/profile_decode_test.c
+++ b/tests/utils/profile_decode_test.c
@@ -356,7 +356,7 @@ static void decode_softsim_profile_test_err_scrubs()
 	printf("Profile struct cleared\n");
 }
 
-/* The six tags every profile the provisioner accepts must carry, see
+/* The four tags the provisioner requires plus the optional OTA keys, see
  * decode_softsim_profile_test_ok. */
 // clang-format off
 #define REQUIRED_TAGS \

--- a/tests/utils/profile_decode_test.ok
+++ b/tests/utils/profile_decode_test.ok
@@ -49,3 +49,23 @@ Profile decode return value: 1
 TEST: A rejected profile leaves no key material behind
 Profile decode return value: 14
 Profile struct cleared
+TEST: Decode a decrypted Onomondo SoftSIM profile that carries only some tags
+Profile decode return value: 0
+TEST: Decode a decrypted Onomondo SoftSIM profile carrying PIN, PUK and ADM
+Profile decode return value: 0
+PIN1: 36383638ffffffff
+PUK1: 3739373937393739
+PUK2: 3739373937393739
+ADM : 8034270253113864
+TEST: Decode a decrypted Onomondo SoftSIM profile with a PIN shorter than the field
+Profile decode return value: 0
+PIN1: 35363738ffffffff
+TEST: Decode a decrypted Onomondo SoftSIM profile whose ADM cannot be stored
+Profile decode return value: 20
+Profile struct cleared
+TEST: Decode a decrypted Onomondo SoftSIM profile whose PIN cannot be stored
+Profile decode return value: 20
+Profile struct cleared
+TEST: Decode a decrypted Onomondo SoftSIM profile whose PIN cannot be stored
+Profile decode return value: 20
+Profile struct cleared

--- a/tests/utils/profile_provision_test.c
+++ b/tests/utils/profile_provision_test.c
@@ -398,6 +398,80 @@ static void provision_profile_keeps_extra_a003_records_test()
 	restore_ef("/3f00/a003", a003_file_shipped, A003_LEN);
 }
 
+/* No Ki tag, so nothing may be written at all. KIC and KID are absent too, which
+ * on its own is a profile the provisioner accepts: they are OTA keys. */
+static const char *decrypted_profile_no_keys = "01"
+					       "12"
+					       "080910101032540636"
+					       "02"
+					       "14"
+					       "98001032547698103214"
+					       "03"
+					       "20"
+					       "00000000000000000000000000000000";
+
+/* An incomplete profile is refused before the first EF is written, rather than
+ * writing NUL over the key material and reporting success. */
+static void provision_profile_missing_tag_test()
+{
+	/* A001 holds the Ki this profile omits, so it is the file at risk. Snapshot it
+	 * rather than comparing against the shipped template: the tests above have
+	 * already provisioned over it. */
+	char a001_before[A001_LEN], a001_after[A001_LEN];
+	int rc;
+
+	printf("TEST: Provision a SoftSIM profile that is missing its Ki\n");
+
+	rc = read_ef("/3f00/a001", a001_before, sizeof(a001_before));
+	assert(rc == 0);
+
+	rc = onomondo_profile_provisioning(decrypted_profile_no_keys);
+	printf("Provisioning return value: %d\n", rc);
+	assert(rc != 0);
+
+	rc = read_ef("/3f00/a001", a001_after, sizeof(a001_after));
+	assert(rc == 0);
+	assert(memcmp(a001_before, a001_after, A001_LEN) == 0);
+	printf("Key material untouched\n");
+}
+
+/* KIC and KID are OTA keys, so a profile without them provisions normally. */
+static const char *decrypted_profile_no_ota_keys = "01"
+						   "12"
+						   "080910101032540636"
+						   "02"
+						   "14"
+						   "98001032547698103214"
+						   "03"
+						   "20"
+						   "00000000000000000000000000000000"
+						   "04"
+						   "20"
+						   "000102030405060708090A0B0C0D0E0F";
+
+static void provision_profile_without_ota_keys_test()
+{
+	char a004[A004_LEN], expect[A004_LEN];
+	int rc;
+
+	printf("TEST: Provision a SoftSIM profile that carries no KIC or KID\n");
+
+	rc = onomondo_profile_provisioning(decrypted_profile_no_ota_keys);
+	printf("Provisioning return value: %d\n", rc);
+	assert(rc == 0);
+
+	/* The key area comes out NUL, which truncates the record when it is read
+	 * back, so remote commands are rejected rather than verified against a key
+	 * the profile never carried. */
+	memcpy(expect, "b00011060101", A004_HEADER_SIZE);
+	memset(&expect[A004_HEADER_SIZE], 0, 2 * KEY_SIZE);
+	memset(&expect[A004_HEADER_SIZE + 2 * KEY_SIZE], 'f', A004_LEN - A004_HEADER_SIZE - 2 * KEY_SIZE);
+	rc = read_ef("/3f00/a004", a004, sizeof(a004));
+	assert(rc == 0);
+	assert(memcmp(a004, expect, A004_LEN) == 0);
+	printf("OTA key area left unusable\n");
+}
+
 /* The PIN code file is optional: a reduced template need not ship it, and the
  * rest of the profile must still be provisioned. */
 static void provision_profile_without_a003_test()
@@ -471,6 +545,8 @@ int main(void)
 	provision_profile_torn_a003_write_test();
 	provision_profile_keeps_extra_a003_records_test();
 	provision_profile_without_a003_test();
+	provision_profile_missing_tag_test();
+	provision_profile_without_ota_keys_test();
 	provision_profile_bad_storage_test();
 	return 0;
 }

--- a/tests/utils/profile_provision_test.c
+++ b/tests/utils/profile_provision_test.c
@@ -6,6 +6,8 @@
  * Author: Benjamin Bruun
  */
 
+#include <assert.h>
+#include <stdbool.h>
 #include <stdio.h>
 #include <string.h>
 #include <onomondo/softsim/storage.h>
@@ -16,6 +18,21 @@
 
 char path[SS_STORAGE_PATH_MAX + 1];
 const char *storage;
+
+static bool tear_a003_write;
+
+/* fs.c declares the storage entry points weak, so this stands in for one and
+ * cuts a single write short on request. The PIN code file is the only EF written
+ * A003_LEN bytes at a time, which is what picks it out. */
+size_t ss_fwrite(const void *ptr, size_t size, size_t count, ss_FILE f)
+{
+	if (tear_a003_write && size == 1 && count == A003_LEN) {
+		tear_a003_write = false;
+		count /= 2;
+	}
+
+	return fwrite(ptr, size, count, (FILE *)f);
+}
 
 /* Reuse the same profile used by profile_decode_test */
 static const char *decrypted_profile_smsp_ok =
@@ -100,9 +117,11 @@ static const char *smsp_file_6f42_updated_smsp_smsc =
 
 static void provision_profile_smsp_test_ok()
 {
+	int rc;
+
 	printf("TEST: Provision a SoftSIM profile with SMSP content\n");
 
-	int rc = onomondo_profile_provisioning(decrypted_profile_smsp_ok);
+	rc = onomondo_profile_provisioning(decrypted_profile_smsp_ok);
 
 	ss_FILE f = ss_fopen(path, "r");
 	if (!f) {
@@ -130,9 +149,11 @@ static void provision_profile_smsp_test_ok()
 
 static void provision_profile_smsc_test_ok()
 {
+	int rc;
+
 	printf("TEST: Provision a SoftSIM profile with SMSC content\n");
 
-	int rc = onomondo_profile_provisioning(decrypted_profile_smsc_ok);
+	rc = onomondo_profile_provisioning(decrypted_profile_smsc_ok);
 
 	ss_FILE f = ss_fopen(path, "r");
 	if (!f) {
@@ -160,11 +181,13 @@ static void provision_profile_smsc_test_ok()
 
 static void provision_profile_smsp_smsc_test_ok()
 {
+	int rc;
+
 	printf("TEST: Provision a SoftSIM profile with SMSP and SMSC content\n");
 
 	/* test that both SMSP and SMSC are provisioned correctly.
      * we will see SMSP provisoned first, and SMSC update the content of SMSP second. */
-	int rc = onomondo_profile_provisioning(decrypted_profile_smsp_smsc_ok);
+	rc = onomondo_profile_provisioning(decrypted_profile_smsp_smsc_ok);
 
 	ss_FILE f = ss_fopen(path, "r");
 	if (!f) {
@@ -188,6 +211,231 @@ static void provision_profile_smsp_smsc_test_ok()
 	}
 
 	printf("Successfully provisioned and validated both SMSP and SMSC\n");
+}
+
+/* PIN 6868, PUK 79797979 and the 16 character ADM 8034270253113864, each as the
+ * hex encoded ASCII the profile carries. */
+static const char *decrypted_profile_pins_ok = "01"
+					       "12"
+					       "080910101032540636"
+					       "02"
+					       "14"
+					       "98001032547698103214"
+					       "03"
+					       "20"
+					       "00000000000000000000000000000000"
+					       "04"
+					       "20"
+					       "000102030405060708090A0B0C0D0E0F"
+					       "05"
+					       "20"
+					       "000102030405060708090A0B0C0D0E0F"
+					       "06"
+					       "20"
+					       "000102030405060708090A0B0C0D0E0F"
+					       "08"
+					       "08"
+					       "36383638"
+					       "0b"
+					       "10"
+					       "3739373937393739"
+					       "0a"
+					       "20"
+					       "38303334323730323533313133383634";
+
+static const char *a003_file_shipped = "0003000a000131323334ffffffff3132333435363738"
+				       "0003000a008131323334ffffffff3132333435363738"
+				       "01030000000a31323334ffffffffffffffffffffffff";
+static const char *a003_file_provisioned = "0003000a000136383638ffffffff3739373937393739"
+					   "0003000a008131323334ffffffff3739373937393739"
+					   "01030000000a8034270253113864ffffffffffffffff";
+
+static int read_ef(const char *rel_path, char *buf, size_t len)
+{
+	char ef_path[SS_STORAGE_PATH_MAX + 1];
+	ss_FILE f;
+	size_t got;
+
+	snprintf(ef_path, sizeof(ef_path), "%s%s", ss_storage_get_path(), rel_path);
+	f = ss_fopen(ef_path, "r");
+	if (!f)
+		return -1;
+
+	got = ss_fread(buf, 1, len, f);
+	ss_fclose(f);
+
+	return got == len ? 0 : -1;
+}
+
+static void restore_ef(const char *rel_path, const char *content, size_t len)
+{
+	char ef_path[SS_STORAGE_PATH_MAX + 1];
+	ss_FILE f;
+
+	snprintf(ef_path, sizeof(ef_path), "%s%s", ss_storage_get_path(), rel_path);
+	f = ss_fopen(ef_path, "w");
+	if (!f) {
+		printf("Warning: failed to reopen %s for restore\n", ef_path);
+		return;
+	}
+
+	ss_fwrite(content, 1, len, f);
+	ss_fclose(f);
+}
+
+/* A profile carrying PIN, PUK and ADM values puts all three into the PIN code
+ * file. The PIN2 record keeps its default PIN, since this profile carries no
+ * PIN2 tag, but takes the PUK. */
+static void provision_profile_pins_test_ok()
+{
+	char a003[A003_LEN];
+	int rc;
+
+	printf("TEST: Provision a SoftSIM profile with PIN, PUK and ADM content\n");
+
+	rc = onomondo_profile_provisioning(decrypted_profile_pins_ok);
+	printf("Provisioning return value: %d\n", rc);
+	assert(rc == 0);
+
+	rc = read_ef("/3f00/a003", a003, sizeof(a003));
+	assert(rc == 0);
+	printf("PIN code file: %.*s\n", A003_LEN, a003);
+	assert(memcmp(a003, a003_file_provisioned, A003_LEN) == 0);
+
+	restore_ef("/3f00/a003", a003_file_shipped, A003_LEN);
+}
+
+/* A profile without PIN tags has nothing to say about the PIN code file, so the
+ * file must come out unchanged. */
+static void provision_profile_no_pins_test_ok()
+{
+	char a003[A003_LEN];
+	int rc;
+
+	printf("TEST: Provision a SoftSIM profile without PIN content\n");
+
+	rc = onomondo_profile_provisioning(decrypted_profile_smsp_ok);
+	printf("Provisioning return value: %d\n", rc);
+	assert(rc == 0);
+
+	rc = read_ef("/3f00/a003", a003, sizeof(a003));
+	assert(rc == 0);
+	assert(memcmp(a003, a003_file_shipped, A003_LEN) == 0);
+	printf("PIN code file unchanged\n");
+}
+
+/* The PIN code file holds state the card maintains, not only what a profile put
+ * there: a PIN the user changed, the retry counter a failed VERIFY decremented.
+ * A profile that carries no PIN value must leave all of it alone. */
+static void provision_profile_keeps_live_pin_state_test()
+{
+	/* Record layout is struct pin_context (uicc_pin.c): enabled, max_tries,
+	 * tries, max_unblock_tries, unblock_tries, pin_no, PIN[8], PUK[8]. This is
+	 * record 1 with the PIN changed to 5678 and two tries spent. */
+	static const char *a003_file_in_use = "0003020a000135363738ffffffff3132333435363738"
+					      "0003000a008131323334ffffffff3132333435363738"
+					      "01030000000a31323334ffffffffffffffffffffffff";
+	char a003[A003_LEN];
+	int rc;
+
+	printf("TEST: Provision a SoftSIM profile without PIN content over a card in use\n");
+
+	restore_ef("/3f00/a003", a003_file_in_use, A003_LEN);
+
+	rc = onomondo_profile_provisioning(decrypted_profile_smsp_ok);
+	printf("Provisioning return value: %d\n", rc);
+	assert(rc == 0);
+
+	rc = read_ef("/3f00/a003", a003, sizeof(a003));
+	assert(rc == 0);
+	assert(memcmp(a003, a003_file_in_use, A003_LEN) == 0);
+	printf("PIN code file left as the card had it\n");
+
+	restore_ef("/3f00/a003", a003_file_shipped, A003_LEN);
+}
+
+/* An EF that was opened and then not written whole is torn, which is a different
+ * answer than a template that never shipped the file. */
+static void provision_profile_torn_a003_write_test()
+{
+	int rc;
+
+	printf("TEST: Provision a SoftSIM profile when the PIN code file write is cut short\n");
+
+	tear_a003_write = true;
+	rc = onomondo_profile_provisioning(decrypted_profile_pins_ok);
+	printf("Provisioning return value: %d\n", rc);
+	assert(rc != 0);
+	tear_a003_write = false;
+
+	restore_ef("/3f00/a003", a003_file_shipped, A003_LEN);
+}
+
+/* The PIN code file is updated, not replaced: a record this format does not
+ * describe must survive provisioning. */
+static void provision_profile_keeps_extra_a003_records_test()
+{
+	char extended[A003_LEN + A003_RECORD_SIZE];
+	char readback[A003_LEN + A003_RECORD_SIZE];
+	int rc;
+
+	printf("TEST: Provision a SoftSIM profile over a PIN code file with an extra record\n");
+
+	memcpy(extended, a003_file_shipped, A003_LEN);
+	memset(&extended[A003_LEN], 'a', A003_RECORD_SIZE);
+	restore_ef("/3f00/a003", extended, sizeof(extended));
+
+	rc = onomondo_profile_provisioning(decrypted_profile_pins_ok);
+	printf("Provisioning return value: %d\n", rc);
+	assert(rc == 0);
+
+	rc = read_ef("/3f00/a003", readback, sizeof(readback));
+	assert(rc == 0);
+	assert(memcmp(readback, a003_file_provisioned, A003_LEN) == 0);
+	assert(memcmp(&readback[A003_LEN], &extended[A003_LEN], A003_RECORD_SIZE) == 0);
+	printf("Extra record preserved\n");
+
+	restore_ef("/3f00/a003", a003_file_shipped, A003_LEN);
+}
+
+/* The PIN code file is optional: a reduced template need not ship it, and the
+ * rest of the profile must still be provisioned. */
+static void provision_profile_without_a003_test()
+{
+	char a003_path[SS_STORAGE_PATH_MAX + 1];
+	int rc;
+
+	printf("TEST: Provision a SoftSIM profile into a storage tree with no PIN code file\n");
+
+	snprintf(a003_path, sizeof(a003_path), "%s%s", ss_storage_get_path(), "/3f00/a003");
+	rc = remove(a003_path);
+	assert(rc == 0);
+
+	rc = onomondo_profile_provisioning(decrypted_profile_pins_ok);
+	printf("Provisioning return value: %d\n", rc);
+	assert(rc == 0);
+
+	restore_ef("/3f00/a003", a003_file_shipped, A003_LEN);
+}
+
+/* A storage tree that cannot be opened must be reported, not written through. */
+static void provision_profile_bad_storage_test()
+{
+	char saved[SS_STORAGE_PATH_MAX];
+	int rc;
+
+	printf("TEST: Provision a SoftSIM profile into a storage path that does not exist\n");
+
+	snprintf(saved, sizeof(saved), "%s", ss_storage_get_path());
+	rc = ss_storage_set_path("./no-such-storage");
+	assert(rc == 0);
+
+	rc = onomondo_profile_provisioning(decrypted_profile_smsp_ok);
+	printf("Provisioning return value: %d\n", rc);
+	assert(rc != 0);
+
+	rc = ss_storage_set_path(saved);
+	assert(rc == 0);
 }
 
 static void restore_ef_smsp()
@@ -217,5 +465,12 @@ int main(void)
 	restore_ef_smsp();
 	provision_profile_smsp_smsc_test_ok();
 	// restore_ef_smsp();
+	provision_profile_pins_test_ok();
+	provision_profile_no_pins_test_ok();
+	provision_profile_keeps_live_pin_state_test();
+	provision_profile_torn_a003_write_test();
+	provision_profile_keeps_extra_a003_records_test();
+	provision_profile_without_a003_test();
+	provision_profile_bad_storage_test();
 	return 0;
 }

--- a/tests/utils/profile_provision_test.ok
+++ b/tests/utils/profile_provision_test.ok
@@ -20,5 +20,11 @@ Provisioning return value: 0
 Extra record preserved
 TEST: Provision a SoftSIM profile into a storage tree with no PIN code file
 Provisioning return value: 0
+TEST: Provision a SoftSIM profile that is missing its Ki
+Provisioning return value: -1
+Key material untouched
+TEST: Provision a SoftSIM profile that carries no KIC or KID
+Provisioning return value: 0
+OTA key area left unusable
 TEST: Provision a SoftSIM profile into a storage path that does not exist
 Provisioning return value: -1

--- a/tests/utils/profile_provision_test.ok
+++ b/tests/utils/profile_provision_test.ok
@@ -4,3 +4,21 @@ TEST: Provision a SoftSIM profile with SMSC content
 Successfully provisioned and validated SMSC update
 TEST: Provision a SoftSIM profile with SMSP and SMSC content
 Successfully provisioned and validated both SMSP and SMSC
+TEST: Provision a SoftSIM profile with PIN, PUK and ADM content
+Provisioning return value: 0
+PIN code file: 0003000a000136383638ffffffff37393739373937390003000a008131323334ffffffff373937393739373901030000000a8034270253113864ffffffffffffffff
+TEST: Provision a SoftSIM profile without PIN content
+Provisioning return value: 0
+PIN code file unchanged
+TEST: Provision a SoftSIM profile without PIN content over a card in use
+Provisioning return value: 0
+PIN code file left as the card had it
+TEST: Provision a SoftSIM profile when the PIN code file write is cut short
+Provisioning return value: -1
+TEST: Provision a SoftSIM profile over a PIN code file with an extra record
+Provisioning return value: 0
+Extra record preserved
+TEST: Provision a SoftSIM profile into a storage tree with no PIN code file
+Provisioning return value: 0
+TEST: Provision a SoftSIM profile into a storage path that does not exist
+Provisioning return value: -1

--- a/utils/ss_profile.c
+++ b/utils/ss_profile.c
@@ -41,6 +41,11 @@ static uint8_t ss_profile_decode(uint16_t len, const char *input_string, struct 
 	/* Stucture (a004): [TAR[3] | MSL | KIC_IND | KID_IND | KIC[32] | KID[32] | */
 	static const char a004_header[] = "b00011060101";
 	const size_t A004_RECORD_SIZE = A004_HEADER_SIZE + KEY_SIZE + KEY_SIZE;
+
+	/* A field the profile carries no tag for is left zeroed, which is how a caller
+	 * tells the two apart. Zeroing here rather than expecting it of the caller. */
+	memset(profile, 0, sizeof *profile);
+
 	/* set the default header values */
 	memcpy(&profile->_3F00_A004, a004_header, sizeof(a004_header) - 1);
 	/* and fill the rest of the record with "f" */

--- a/utils/ss_profile.c
+++ b/utils/ss_profile.c
@@ -6,7 +6,9 @@
  * Author: Onomondo ApS
  */
 
+#include <stdbool.h>
 #include <string.h>
+#include "onomondo/softsim/log.h"
 #include "onomondo/utils/ss_profile.h"
 
 static uint8_t ss_hex_to_uint8(const char *hex);
@@ -14,6 +16,7 @@ static void ss_hex_string_to_bytes(const uint8_t *hex, size_t hex_len, uint8_t *
 static uint32_t ss_profile_uint32_from_hex(const char *hex);
 static void ss_profile_wipe(void *ptr, size_t len);
 static uint8_t ss_profile_decode(uint16_t len, const char *input_string, struct ss_profile *profile);
+static bool ss_profile_copy_pin(uint8_t *field, const char *data, uint8_t data_len);
 
 uint8_t ss_profile_from_string(uint16_t len, const char *input_string, struct ss_profile *profile)
 {
@@ -52,6 +55,8 @@ static uint8_t ss_profile_decode(uint16_t len, const char *input_string, struct 
 	uint8_t tag = 0, data_len = 0;
 
 	while (pos + 4 <= len) {
+		bool pin_fits = true;
+
 		data_start = pos + 4;
 		tag = ss_hex_to_uint8((char *)&input_string[pos]);
 		data_len = ss_hex_to_uint8((char *)&input_string[pos + 2]);
@@ -109,30 +114,22 @@ static uint8_t ss_profile_decode(uint16_t len, const char *input_string, struct 
 			memcpy(&profile->SMSC, &input_string[data_start], data_len);
 			break;
 		case PIN_1_TAG:
-			if (data_len > PIN_SIZE)
-				break;
-			memcpy(&profile->_3F00_A003[0 * A003_RECORD_SIZE + PIN_OFFSET], &input_string[data_start],
-			       data_len);
+			pin_fits = ss_profile_copy_pin(&profile->_3F00_A003[0 * A003_RECORD_SIZE + PIN_OFFSET],
+						       &input_string[data_start], data_len);
 			break;
 		case PIN_2_TAG:
-			if (data_len > PIN_SIZE)
-				break;
-			memcpy(&profile->_3F00_A003[1 * A003_RECORD_SIZE + PIN_OFFSET], &input_string[data_start],
-			       data_len);
+			pin_fits = ss_profile_copy_pin(&profile->_3F00_A003[1 * A003_RECORD_SIZE + PIN_OFFSET],
+						       &input_string[data_start], data_len);
 			break;
 		case PIN_ADM_TAG:
-			if (data_len > PIN_SIZE)
-				break;
-			memcpy(&profile->_3F00_A003[2 * A003_RECORD_SIZE + PIN_OFFSET], &input_string[data_start],
-			       data_len);
+			pin_fits = ss_profile_copy_pin(&profile->_3F00_A003[2 * A003_RECORD_SIZE + PIN_OFFSET],
+						       &input_string[data_start], data_len);
 			break;
 		case PUK_TAG:
-			if (data_len > PIN_SIZE)
-				break;
-			memcpy(&profile->_3F00_A003[0 * A003_RECORD_SIZE + PUK_OFFSET], &input_string[data_start],
-			       data_len);
-			memcpy(&profile->_3F00_A003[1 * A003_RECORD_SIZE + PUK_OFFSET], &input_string[data_start],
-			       data_len);
+			pin_fits = ss_profile_copy_pin(&profile->_3F00_A003[0 * A003_RECORD_SIZE + PUK_OFFSET],
+						       &input_string[data_start], data_len) &&
+				   ss_profile_copy_pin(&profile->_3F00_A003[1 * A003_RECORD_SIZE + PUK_OFFSET],
+						       &input_string[data_start], data_len);
 			break;
 		case CRC32_TAG:
 			if (data_len != CRC32_LEN)
@@ -158,6 +155,16 @@ static uint8_t ss_profile_decode(uint16_t len, const char *input_string, struct 
 		default:
 			/* unknown tag, skip (next_pos already points to the right location) */
 			break;
+		}
+
+		/* Refused rather than skipped, because the alternative is a card left on
+		 * the shipped default while the profile says the value was rotated. Every
+		 * other tag rejects a value it cannot store, and so does this one. */
+		if (!pin_fits) {
+			SS_LOGP(SPIN, LERROR,
+				"profile tag %02x carries %u characters that no PIN code file record can hold\n",
+				(unsigned int)tag, (unsigned int)data_len);
+			return 20;
 		}
 
 		/* move the parser to the next position after handling the tag */
@@ -216,6 +223,70 @@ static uint32_t ss_profile_uint32_from_hex(const char *hex)
 {
 	return ((uint32_t)ss_hex_to_uint8(&hex[0]) << 24) | ((uint32_t)ss_hex_to_uint8(&hex[2]) << 16) |
 	       ((uint32_t)ss_hex_to_uint8(&hex[4]) << 8) | (uint32_t)ss_hex_to_uint8(&hex[6]);
+}
+
+static bool is_hex_digit(uint8_t c)
+{
+	return (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F');
+}
+
+/** Copy a PIN, PUK or ADM value into a PIN code file record.
+ *
+ *  A record holds the value as the 16 hex characters of its 8 bytes, which is
+ *  what the profile carries for a value of up to 8 characters. A 16 character
+ *  value does not fit that way, but when it is itself hex it names those 8 bytes
+ *  exactly -- the usual form of an ADM key -- so unwrap one layer of encoding
+ *  instead of dropping it. Anything longer cannot be stored, nor presented:
+ *  TS 102 221 clause 11.1.9.3 carries a PIN in exactly 8 bytes.
+ *
+ *  A short value is padded with 'f' so the unused bytes read as the 'FF' padding
+ *  TS 31.101 clause 9.6 expects. The same clause sets a four digit minimum,
+ *  which is eight characters here. Every character has to be hex either way: the
+ *  record is a hex string, and whatever goes in comes back out through a hex
+ *  decoder.
+ *
+ *  \param[out] field the 16 character field to fill, left untouched on failure
+ *  \param[in] data the value as it appears in the profile
+ *  \param[in] data_len length of data in characters
+ *  \returns true if the value was stored */
+static bool ss_profile_copy_pin(uint8_t *field, const char *data, uint8_t data_len)
+{
+	uint8_t unwrapped[PIN_SIZE];
+	size_t i;
+
+	/* Two characters per digit, and TS 31.101 clause 9.6 wants at least four. */
+	if (data_len < 8 || data_len % 2)
+		return false;
+
+	if (data_len <= PIN_SIZE) {
+		/* The record is read back as hex pairs, so a character that is not hex
+		 * names no byte -- it decodes to the 0xFF padding and shortens the value
+		 * the card ends up holding. */
+		for (i = 0; i < data_len; i++) {
+			if (!is_hex_digit((uint8_t)data[i]))
+				return false;
+		}
+		memcpy(field, data, data_len);
+		memset(&field[data_len], 'f', PIN_SIZE - data_len);
+		return true;
+	}
+
+	if (data_len != 2 * PIN_SIZE)
+		return false;
+
+	/* Both layers have to be hex: the characters that arrive, so they spell a byte
+	 * at all, and the characters they spell, because those are what the record
+	 * stores. */
+	for (i = 0; i < PIN_SIZE; i++) {
+		if (!is_hex_digit((uint8_t)data[i * 2]) || !is_hex_digit((uint8_t)data[i * 2 + 1]))
+			return false;
+		unwrapped[i] = ss_hex_to_uint8(&data[i * 2]);
+		if (!is_hex_digit(unwrapped[i]))
+			return false;
+	}
+
+	memcpy(field, unwrapped, PIN_SIZE);
+	return true;
 }
 
 /** Hex to uint8 converter

--- a/utils/ss_profile.c
+++ b/utils/ss_profile.c
@@ -46,9 +46,11 @@ static uint8_t ss_profile_decode(uint16_t len, const char *input_string, struct 
 	/* and fill the rest of the record with "f" */
 	memset(&profile->_3F00_A004[A004_RECORD_SIZE], 'f', A004_LEN - A004_RECORD_SIZE);
 
-	/* Structure (a003): */
+	/* Structure (a003): three records of [header(12) | PIN(16) | PUK(16)]. Must
+	 * match the shipped PIN code file: the record is written out whether or not
+	 * the profile carried a PIN, and the ADM record has no PUK. */
 	static const char a003_default[] = "0003000a000131323334ffffffff31323334353637380003000a008131323334ffffff"
-					   "ff313233343536373801030000000a31323334ffffffff3132333435363738";
+					   "ff313233343536373801030000000a31323334ffffffffffffffffffffffff";
 	memcpy(profile->_3F00_A003, a003_default, sizeof(a003_default) - 1);
 
 	size_t pos = 0, data_end = 0, data_start = 0, next_pos = 0;
@@ -156,6 +158,11 @@ static uint8_t ss_profile_decode(uint16_t len, const char *input_string, struct 
 			/* unknown tag, skip (next_pos already points to the right location) */
 			break;
 		}
+
+		/* The PIN code file holds state the card maintains, so the provisioner
+		 * needs to know whether the profile has anything to say about it. */
+		if (tag == PIN_1_TAG || tag == PIN_2_TAG || tag == PIN_ADM_TAG || tag == PUK_TAG)
+			profile->pin_present = 1;
 
 		/* Refused rather than skipped, because the alternative is a card left on
 		 * the shipped default while the profile says the value was rotated. Every

--- a/utils/ss_profile.c
+++ b/utils/ss_profile.c
@@ -14,7 +14,6 @@
 static uint8_t ss_hex_to_uint8(const char *hex);
 static void ss_hex_string_to_bytes(const uint8_t *hex, size_t hex_len, uint8_t *bytes);
 static uint32_t ss_profile_uint32_from_hex(const char *hex);
-static void ss_profile_wipe(void *ptr, size_t len);
 static uint8_t ss_profile_decode(uint16_t len, const char *input_string, struct ss_profile *profile);
 static bool ss_profile_copy_pin(uint8_t *field, const char *data, uint8_t data_len);
 
@@ -25,7 +24,7 @@ uint8_t ss_profile_from_string(uint16_t len, const char *input_string, struct ss
 	/* Ki, OPc, KIC, KID, PINs and PUK are already in the struct by the time a
 	 * later record fails a check, and the caller frees without scrubbing. */
 	if (rc)
-		ss_profile_wipe(profile, sizeof *profile);
+		ss_profile_wipe(profile);
 	return rc;
 }
 
@@ -189,18 +188,15 @@ static uint8_t ss_profile_decode(uint16_t len, const char *input_string, struct 
 	return 0;
 }
 
-/** Clear a buffer that is about to be released.
- *  Writes through a volatile pointer so the compiler keeps stores to storage it
- *  can see is dead. The uicc library has ss_memzero() for this, but utils links
- *  without it.
- *  \param[out] ptr buffer to clear.
- *  \param[in] len number of bytes. */
-static void ss_profile_wipe(void *ptr, size_t len)
+/* See in ss_profile.h. Writes through a volatile pointer so the compiler keeps
+ * stores to storage it can see is dead. The uicc library has ss_memzero() for
+ * this, but utils links without it. */
+void ss_profile_wipe(struct ss_profile *profile)
 {
-	volatile char *clear_this = (volatile char *)ptr;
+	volatile char *clear_this = (volatile char *)profile;
 	size_t i;
 
-	for (i = 0; i < len; i++)
+	for (i = 0; i < sizeof *profile; i++)
 		clear_this[i] = 0;
 }
 

--- a/utils/ss_provision.c
+++ b/utils/ss_provision.c
@@ -2,12 +2,13 @@
  * Copyright (c) 2024 Onomondo ApS. All rights reserved.
  *
  * SPDX-License-Identifier: GPL-3.0-only
- * 
+ *
  * Author: Onomondo ApS
  */
 
 #include <stdio.h>
 #include <string.h>
+#include "onomondo/softsim/log.h"
 #include "onomondo/softsim/mem.h"
 #include "onomondo/softsim/fs.h"
 #include "onomondo/softsim/storage.h"
@@ -19,78 +20,101 @@
 static const char *ICCID_REL_PATH = PATH_SEPARATOR "3f00" PATH_SEPARATOR "2fe2";
 static const char *IMSI_REL_PATH = PATH_SEPARATOR "3f00" PATH_SEPARATOR "7ff0" PATH_SEPARATOR "6f07";
 static const char *A001_REL_PATH = PATH_SEPARATOR "3f00" PATH_SEPARATOR "a001";
+static const char *A003_REL_PATH = PATH_SEPARATOR "3f00" PATH_SEPARATOR "a003";
 static const char *A004_REL_PATH = PATH_SEPARATOR "3f00" PATH_SEPARATOR "a004";
 static const char *SMSP_REL_PATH = PATH_SEPARATOR "3f00" PATH_SEPARATOR "7ff0" PATH_SEPARATOR "6f42";
+
+/* SMSC offset inside EF.SMSP, in characters */
+#define SMSC_OFFSET 74
+
+/*! Write one EF inside storage
+ *  \param[in] rel_path path of the EF relative to the storage root
+ *  \param[in] mode "w" to replace the EF, "r+" to update it without truncating
+ *  \param[in] offset offset to write at
+ *  \param[in] data data to write
+ *  \param[in] len length of data
+ *  \returns 0 on success, -1 if the EF could not be opened, -2 if it was opened
+ *  and not written whole */
+static int write_ef(const char *rel_path, char *mode, long offset, const void *data, size_t len)
+{
+	char path[SS_STORAGE_PATH_MAX + 1];
+	ss_FILE f;
+	size_t wrote;
+	int path_len;
+
+	path_len = snprintf(path, sizeof(path), "%s%s", ss_storage_get_path(), rel_path);
+	if (path_len < 0 || (size_t)path_len >= sizeof(path))
+		return -2;
+
+	/* "r+" does not create the EF, so a template tree missing it lands here. */
+	f = ss_fopen(path, mode);
+	if (!f)
+		return -1;
+
+	if (offset != 0 && ss_fseek(f, offset, SEEK_SET) != 0) {
+		ss_fclose(f);
+		return -2;
+	}
+
+	wrote = ss_fwrite(data, 1, len, f);
+
+	/* An EF that was opened and then not written whole is torn, which is a
+	 * different answer than one that was never there. The close carries that too:
+	 * a buffered write reports a full disk there. */
+	if (ss_fclose(f) != 0 || wrote != len)
+		return -2;
+
+	return 0;
+}
 
 /*! Write the decoded profile to the SoftSIM filesystem
  *  \param[in] profile Pointer to the decoded SoftSIM profile
  *  \returns 0 on success, -1 on failure */
 static int write_profile_to_fs(const struct ss_profile *profile)
 {
-	size_t wrote = 0;
-	ss_FILE f = NULL;
-	char path[SS_STORAGE_PATH_MAX + 1];
-	const char *storage = ss_storage_get_path();
+	const uint8_t zeros[SMSP_RECORD_SIZE * 2] = { 0 };
+	int rc;
 
-	/* write ICCID */
-	snprintf(path, sizeof(path), "%s%s", storage, ICCID_REL_PATH);
-	f = ss_fopen(path, "w");
-	wrote = ss_fwrite(profile->_3F00_2FE2, 1, ICCID_LEN, f);
-	ss_fclose(f);
-	if (wrote == 0 || wrote != ICCID_LEN)
-		goto exit;
+	if (write_ef(ICCID_REL_PATH, "w", 0, profile->_3F00_2FE2, ICCID_LEN) != 0)
+		return -1;
 
-	/* write IMSI */
-	snprintf(path, sizeof(path), "%s%s", storage, IMSI_REL_PATH);
-	f = ss_fopen(path, "w");
-	wrote = ss_fwrite(profile->_3F00_7ff0_6f07, 1, IMSI_LEN, f);
-	ss_fclose(f);
-	if (wrote == 0 || wrote != IMSI_LEN)
-		goto exit;
+	if (write_ef(IMSI_REL_PATH, "w", 0, profile->_3F00_7ff0_6f07, IMSI_LEN) != 0)
+		return -1;
 
-	/* write A001 */
-	snprintf(path, sizeof(path), "%s%s", storage, A001_REL_PATH);
-	f = ss_fopen(path, "w");
-	wrote = ss_fwrite(profile->_3F00_A001, 1, A001_LEN, f);
-	ss_fclose(f);
-	if (wrote == 0 || wrote != A001_LEN)
-		goto exit;
+	if (write_ef(A001_REL_PATH, "w", 0, profile->_3F00_A001, A001_LEN) != 0)
+		return -1;
 
-	/* write A004 */
-	snprintf(path, sizeof(path), "%s%s", storage, A004_REL_PATH);
-	f = ss_fopen(path, "w");
-	wrote = ss_fwrite(profile->_3F00_A004, 1, A004_LEN, f);
-	ss_fclose(f);
-	if (wrote == 0 || wrote != A004_LEN)
-		goto exit;
-
-	/* write EF.SMSP */
-	uint8_t zeros_smsp[SMSP_RECORD_SIZE * 2] = { 0 };
-	if (memcmp(profile->SMSP, zeros_smsp, (SMSP_RECORD_SIZE * 2)) != 0) {
-		snprintf(path, sizeof(path), "%s%s", storage, SMSP_REL_PATH);
-		f = ss_fopen(path, "r+"); /* open for update without truncation */
-		wrote = ss_fwrite(profile->SMSP, 1, (SMSP_RECORD_SIZE * 2), f);
-		ss_fclose(f);
-		if (wrote == 0 || wrote != (SMSP_RECORD_SIZE * 2))
-			goto exit;
+	/* PIN code file. It holds state the card maintains -- a PIN the user changed,
+	 * the enabled flag, the retry and unblock counters -- so it is written only
+	 * when the profile carries a value to put in it. Writing it unconditionally
+	 * would put the shipped defaults back over all of that.
+	 *
+	 * Updated rather than replaced: a template may hold records this format does
+	 * not describe, and those must survive. Optional, because a reduced template
+	 * need not ship the file at all: "r+" does not create it, and a file that was
+	 * never there is the one failure this EF forgives. A torn write is not. */
+	if (profile->pin_present) {
+		rc = write_ef(A003_REL_PATH, "r+", 0, profile->_3F00_A003, A003_LEN);
+		if (rc == -1)
+			SS_LOGP(SPIN, LINFO, "no PIN code file to update, keeping the card's PIN configuration\n");
+		else if (rc != 0)
+			return -1;
 	}
 
-	/* write SMSC in EF.SMSP */
-	uint8_t zeros_smsc[SMSC_LEN] = { 0 };
-	if (memcmp(profile->SMSC, zeros_smsc, SMSC_LEN) != 0) {
-		snprintf(path, sizeof(path), "%s%s", storage, SMSP_REL_PATH);
-		f = ss_fopen(path, "r+"); /* open for update without truncation */
-		ss_fseek(f, 74, SEEK_SET); /* Move to SMSC offset in EF.SMSP */
-		wrote = ss_fwrite(profile->SMSC, 1, SMSC_LEN, f);
-		ss_fclose(f);
-		if (wrote == 0 || wrote != SMSC_LEN)
-			goto exit;
-	}
+	if (write_ef(A004_REL_PATH, "w", 0, profile->_3F00_A004, A004_LEN) != 0)
+		return -1;
+
+	/* EF.SMSP and the SMSC inside it are optional: a profile carrying neither
+	 * keeps what the template shipped. */
+	if (memcmp(profile->SMSP, zeros, SMSP_RECORD_SIZE * 2) != 0 &&
+	    write_ef(SMSP_REL_PATH, "r+", 0, profile->SMSP, SMSP_RECORD_SIZE * 2) != 0)
+		return -1;
+
+	if (memcmp(profile->SMSC, zeros, SMSC_LEN) != 0 &&
+	    write_ef(SMSP_REL_PATH, "r+", SMSC_OFFSET, profile->SMSC, SMSC_LEN) != 0)
+		return -1;
 
 	return 0;
-
-exit:
-	return -1;
 }
 
 /*! Provision a SoftSIM profile from e.g. an AT command string
@@ -99,6 +123,10 @@ exit:
 int onomondo_profile_provisioning(const char *at_profile)
 {
 	struct ss_profile *profile = SS_ALLOC(*profile);
+
+	if (!profile)
+		return -1;
+
 	memset(profile, 0, sizeof *profile);
 
 	/* Validate the size of the profile hiding in the FS */
@@ -109,8 +137,6 @@ int onomondo_profile_provisioning(const char *at_profile)
 		goto exit;
 
 	rc = write_profile_to_fs(profile);
-	if (rc != 0)
-		goto exit;
 
 exit:
 	SS_FREE(profile);

--- a/utils/ss_provision.c
+++ b/utils/ss_provision.c
@@ -6,6 +6,7 @@
  * Author: Onomondo ApS
  */
 
+#include <stdint.h>
 #include <stdio.h>
 #include <string.h>
 #include "onomondo/softsim/log.h"
@@ -73,7 +74,33 @@ static int write_ef(const char *rel_path, char *mode, long offset, const void *d
 static int write_profile_to_fs(const struct ss_profile *profile)
 {
 	const uint8_t zeros[SMSP_RECORD_SIZE * 2] = { 0 };
+	const char *missing = NULL;
 	int rc;
+
+	/* The EFs below are written whether or not the profile carried the tag that
+	 * fills them, so a field the profile left empty has to be caught here. The
+	 * parser zeroes the struct and writes only what it found, so an absent tag
+	 * leaves its field zeroed. Judged on the hex characters and never on the
+	 * decoded keys: an all-zero Ki or OPc is a legitimate value, and it arrives
+	 * here as '0' characters, not as NUL.
+	 *
+	 * KIC and KID are deliberately absent from the list. They are OTA keys
+	 * (TS 102 225, TS 31.115) and a device that never receives a secured packet
+	 * has no use for them, so the exporter emits them only when the profile has
+	 * them. The four below are the ones that leave an unusable card when zeroed. */
+	if (memcmp(profile->_3F00_2FE2, zeros, ICCID_LEN) == 0)
+		missing = "ICCID";
+	else if (memcmp(profile->_3F00_7ff0_6f07, zeros, IMSI_LEN) == 0)
+		missing = "IMSI";
+	else if (memcmp(&profile->_3F00_A001[0], zeros, KEY_SIZE) == 0)
+		missing = "Ki";
+	else if (memcmp(&profile->_3F00_A001[KEY_SIZE], zeros, KEY_SIZE) == 0)
+		missing = "OPc";
+
+	if (missing) {
+		SS_LOGP(SSTORAGE, LERROR, "profile carries no %s, refusing to provision it\n", missing);
+		return -1;
+	}
 
 	if (write_ef(ICCID_REL_PATH, "w", 0, profile->_3F00_2FE2, ICCID_LEN) != 0)
 		return -1;
@@ -123,16 +150,19 @@ static int write_profile_to_fs(const struct ss_profile *profile)
 int onomondo_profile_provisioning(const char *at_profile)
 {
 	struct ss_profile *profile = SS_ALLOC(*profile);
+	size_t input_string_size;
+	int rc;
 
 	if (!profile)
 		return -1;
 
-	memset(profile, 0, sizeof *profile);
+	input_string_size = strlen(at_profile);
+	if (input_string_size > UINT16_MAX) {
+		rc = -1;
+		goto exit;
+	}
 
-	/* Validate the size of the profile hiding in the FS */
-	uint16_t input_string_size = strlen(at_profile);
-
-	int rc = ss_profile_from_string(input_string_size, at_profile, profile);
+	rc = ss_profile_from_string((uint16_t)input_string_size, at_profile, profile);
 	if (rc != 0)
 		goto exit;
 

--- a/utils/ss_provision.c
+++ b/utils/ss_provision.c
@@ -169,6 +169,10 @@ int onomondo_profile_provisioning(const char *at_profile)
 	rc = write_profile_to_fs(profile);
 
 exit:
+	/* The struct holds Ki, OPc and the OTA keys; scrub before the allocator
+	 * reuses the memory. Already cleared on a decode error, but cheap to not
+	 * have to know that here. */
+	ss_profile_wipe(profile);
 	SS_FREE(profile);
 	return rc;
 }


### PR DESCRIPTION
Last of three layers, stacked on #131: the parser stays inside its buffer (#126), the CRC record
says the blob arrived intact (#131), and this one makes the write correct.

To sanction: KIC and KID are not required, being OTA keys the exporter emits conditionally, and a
missing `/3f00/a003` is skipped rather than failing the provision. Still open: provisioning is not
atomic, so power loss part way through leaves a mixed profile — all validation now happens before
the first write, which shrinks the window without closing it.

Details and the load-bearing tests are in the three commit messages.
