### PR TITLE
fix: check the response buffer before writing the first byte

### DIFF
--- a/src/softsim/uicc/softsim.c
+++ b/src/softsim/uicc/softsim.c
@@ -438,7 +438,7 @@ out:
  *  \param[in] response_buf_len maxium length of the resulting response APDU.
  *  \param[in] request_buf user provided memory with request APDU.
  *  \param[inout] request_len length of the request APDU.
- *  \returns length of the resulting response APDU. */
+ *  \returns length of the resulting response APDU, 0 if response_buf is too small. */
 size_t ss_transact(struct ss_context *ctx, uint8_t *response_buf, size_t response_buf_len, uint8_t *request_buf,
 		   size_t *request_len)
 {
@@ -452,6 +452,16 @@ size_t ss_transact(struct ss_context *ctx, uint8_t *response_buf, size_t respons
 	int processed_length;
 	size_t _request_len = *request_len;
 
+	/* A card response can consume the whole response body plus the status
+	 * word, so a caller that provides less than that cannot be served. This
+	 * has to precede every write below, including the status word written on
+	 * the short-APDU path. */
+	if (response_buf_len < sizeof(apdu->rsp) + sizeof(apdu->sw)) {
+		SS_LOGP(SIFACE, LERROR, "response buffer holds %u bytes, %u are required\n",
+			(unsigned int)response_buf_len, (unsigned int)(sizeof(apdu->rsp) + sizeof(apdu->sw)));
+		return 0;
+	}
+
 	/* A T=0 TPDU carries at least the 5-byte header (CLA INS P1 P2 P3) that
 	 * is copied below; anything shorter is rejected. Header-only Case 1
 	 * APDUs are served by ss_application_apdu_transact(). */
@@ -463,10 +473,6 @@ size_t ss_transact(struct ss_context *ctx, uint8_t *response_buf, size_t respons
 		*request_len = _request_len;
 		return 2;
 	}
-
-	/* A card response can consume up to 255 bytes, it must be ensured that
-	 * the response buffer is large enough. */
-	assert(response_buf_len >= sizeof(apdu->rsp) + sizeof(apdu->sw));
 
 	/* Limit the request length to the maximum length of an APDU. It is
 	 * legal to call this function with a request lengths far longer than
@@ -532,7 +538,7 @@ size_t ss_transact(struct ss_context *ctx, uint8_t *response_buf, size_t respons
  *  \param[in] response_buf_len maximum length of the resulting response APDU.
  *  \param[in] request_buf user provided memory with request APDU.
  *  \param[in] request_len length of the request APDU, must not be longer than 5+265 bytes.
- *  \returns length of the resulting response APDU. */
+ *  \returns length of the resulting response APDU, 0 if response_buf is too small. */
 size_t ss_application_apdu_transact(struct ss_context *ctx, uint8_t *response_buf, size_t response_buf_len,
 				    uint8_t *request_buf, size_t *request_len)
 {
@@ -542,6 +548,16 @@ size_t ss_application_apdu_transact(struct ss_context *ctx, uint8_t *response_bu
 	size_t _request_len = *request_len;
 	uint16_t le = 0;
 
+	/* A card response can consume the whole response body plus the status
+	 * word, so a caller that provides less than that cannot be served. This
+	 * has to precede every write below, including the status word written on
+	 * the short-APDU path. */
+	if (response_buf_len < sizeof(apdu->rsp) + sizeof(apdu->sw)) {
+		SS_LOGP(SIFACE, LERROR, "response buffer holds %u bytes, %u are required\n",
+			(unsigned int)response_buf_len, (unsigned int)(sizeof(apdu->rsp) + sizeof(apdu->sw)));
+		return 0;
+	}
+
 	/* Allow 4-byte Case 1 APDUs (header only: CLA INS P1 P2)
 	 * The parser ss_apdu_parse_exhaustive supports this format */
 	if (_request_len < 4) {
@@ -550,10 +566,6 @@ size_t ss_application_apdu_transact(struct ss_context *ctx, uint8_t *response_bu
 		response_buf[response_len++] = SS_SW_ERR_CHECKING_WRONG_LENGTH & 0xff;
 		return 2;
 	}
-
-	/* A card response can consume up to 256 bytes, it must be ensured that
-	* the response buffer is large enough. */
-	assert(response_buf_len >= sizeof(apdu->rsp) + sizeof(apdu->sw));
 
 	if (_request_len > sizeof(apdu->cmd) + sizeof(apdu->hdr)) {
 		SS_LOGP(SIFACE, LINFO, "request exceeds maximum length %zu > %zu, will truncate.\n", _request_len,

--- a/src/softsim/uicc/uicc_remote_cmd.c
+++ b/src/softsim/uicc/uicc_remote_cmd.c
@@ -17,6 +17,7 @@
 #include <onomondo/softsim/softsim.h>
 #include <onomondo/softsim/crypto.h>
 
+#include "apdu.h"
 #include "context.h"
 #include "fcp.h"
 #include "fs.h"
@@ -81,6 +82,14 @@ struct cntr_record {
 /* Arbitrary limit for response sizes: "The limitation of 256 bytes does not
  * apply for the length of the response data." */
 #define SS_UICC_REMOTE_COMMAND_RESPONSE_MAXSIZE 4096
+
+/* ss_transact() refuses a response buffer that cannot hold a full R-APDU and
+ * returns 0; process_commands() below reads the SW back out of the buffer
+ * without checking for that, so the space left after the OTA response header
+ * has to clear the bar. */
+_Static_assert(SS_UICC_REMOTE_COMMAND_RESPONSE_MAXSIZE - (16 + OTA_INTEGRITY_LEN) - 3 >=
+		       sizeof(((struct ss_apdu *)0)->rsp) + sizeof(((struct ss_apdu *)0)->sw),
+	       "RFM response buffer too small for the ss_transact() contract");
 
 /* See also ETSI TS 102 225, section 5.1.1 */
 enum cntr_mgmnt {

--- a/tests/init/init_test.c
+++ b/tests/init/init_test.c
@@ -139,6 +139,52 @@ static void transact_unresolved_lchan_test(struct ss_context *ctx)
 	}
 }
 
+/* Both entry points write up to sizeof(apdu->rsp) + sizeof(apdu->sw) bytes, so a
+ * caller that offers less is refused before anything is written -- including the
+ * short-request path, which answers 6700 straight into the buffer. */
+static void transact_short_response_buf_test(struct ss_context *ctx)
+{
+	/* one well-formed SELECT and one too-short request: the short one takes the
+	 * early-return path that writes the status word */
+	static const char *const cases[] = { "00a4000c023f00", "00a4" };
+	size_t i, len;
+
+	for (i = 0; i < SS_ARRAY_SIZE(cases); i++) {
+		for (len = 0; len < 258; len++) {
+			uint8_t cmd[16];
+			size_t cmd_len;
+			size_t resp_len;
+			/* sized to exactly what is offered, so a write past it is an
+			 * ASan report rather than a scribble on a roomy stack array */
+			uint8_t *tight = malloc(len ? len : 1);
+
+			assert(tight);
+
+			/* the calls stay outside the asserts: NDEBUG drops the whole
+			 * expression, and this run has to reach them to mean anything */
+			cmd_len = ss_binary_from_hexstr(cmd, sizeof(cmd), cases[i]);
+			resp_len = ss_transact(ctx, tight, len, cmd, &cmd_len);
+			assert(resp_len == 0);
+
+			cmd_len = ss_binary_from_hexstr(cmd, sizeof(cmd), cases[i]);
+			resp_len = ss_application_apdu_transact(ctx, tight, len, cmd, &cmd_len);
+			assert(resp_len == 0);
+
+			free(tight);
+		}
+	}
+
+	/* the contract length itself is served */
+	{
+		uint8_t buf[258];
+		uint8_t cmd[16];
+		size_t cmd_len = ss_binary_from_hexstr(cmd, sizeof(cmd), cases[0]);
+		size_t resp_len = ss_transact(ctx, buf, sizeof(buf), cmd, &cmd_len);
+
+		assert(resp_len == 2);
+	}
+}
+
 int main(void)
 {
 	struct ss_context *ctx;
@@ -153,6 +199,9 @@ int main(void)
 	ss_reset(ctx);
 
 	transact_unresolved_lchan_test(ctx);
+	ss_reset(ctx);
+
+	transact_short_response_buf_test(ctx);
 	ss_reset(ctx);
 
 	size_t cmd_len = 0;


### PR DESCRIPTION
`ss_transact()` and `ss_application_apdu_transact()` wrote the status word into the caller's response buffer before any size check, so a caller providing fewer than two bytes was overrun even with asserts compiled in — and the assert that guarded the full-size case vanishes under `NDEBUG`. Both entry points now check the contract before the first write and return 0.

No in-tree caller can trip it (`main.c` passes 258 bytes, the RFM path ~4069 of a 4096-byte message); this is an integrator-facing contract on the two functions exported in the public header.

Covered by a case in init_test that drives both entry points with exact-sized heap buffers from 0 up to one below the requirement; removing either guard reproduces a 1-byte heap-buffer-overflow under ASan.