### PR TITLE
test: snapshot files/ at configure time for envelope_test

### DIFF
--- a/tests/envelope/CMakeLists.txt
+++ b/tests/envelope/CMakeLists.txt
@@ -9,11 +9,17 @@ target_link_libraries(envelope_test uicc milenage crypto storage $<$<TARGET_EXIS
 # encrypted with keys stored in files/; the identity stub used for
 # CONFIG_EXTERNAL_KEY_LOAD produces different crypto output.
 if(NOT CONFIG_EXTERNAL_KEY_LOAD)
-    # Copy files/ to build dir before each test run so CNTR writes don't touch
+    # Snapshot files/ at configure time, as tests/key_scrub and tests/app_transact
+    # do: with CONFIG_USE_UTILS the suite's own profile_provision_test rewrites the
+    # source tree mid-run (keys in 3f00/a001 and 3f00/a004), so a copy taken while
+    # ctest is running can stage a mutated profile.
+    file(COPY ${CMAKE_SOURCE_DIR}/files DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/pristine)
+
+    # Refresh from that snapshot before each test run so CNTR writes don't touch
     # the source tree and the test is idempotent across repeated ctest runs.
     add_test(NAME envelope_test_setup
         COMMAND ${CMAKE_COMMAND} -E copy_directory
-            ${CMAKE_SOURCE_DIR}/files
+            ${CMAKE_CURRENT_BINARY_DIR}/pristine/files
             ${CMAKE_CURRENT_BINARY_DIR}/files
     )
     set_tests_properties(envelope_test_setup PROPERTIES FIXTURES_SETUP envelope_files)


### PR DESCRIPTION
`envelope_test` and `envelope_test_compare` fail on the second consecutive `ctest` run on an
unmodified checkout configured with `-DCONFIG_USE_UTILS=y`. CI never sees it because every
matrix cell runs `ctest` exactly once on a fresh checkout; it bites anyone running the suite twice
locally.

The fix takes the copy of `files/` at configure time into `<bindir>/pristine` and points the
existing per-run fixture refresh at that snapshot — the same arrangement `tests/key_scrub` and
`tests/app_transact` use.