### PR TITLE
test: fuzz the APDU and profile parsers

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -1,0 +1,117 @@
+name: Fuzz
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # Replays the fuzz seed corpora and exits. This is the safety net that keeps a
+  # fixed crash fixed, so unlike the search below it runs on every PR. It needs
+  # its own job because CONFIG_BUILD_FUZZERS requires clang, which rules out
+  # adding it to the uicc-build-and-test matrix in ci_uicc.yml.
+  fuzz-corpus:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout Project
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Install CMake
+        uses: lukka/get-cmake@f5b8fbb4d77cec1acc5a5f9f0df4beffaf5d98d9 # v4.3.4
+        with:
+          cmakeVersion: 3.27.0
+          ninjaVersion: 1.11.1
+
+      - name: Install CLANG
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang libclang-rt-18-dev llvm-18
+
+      - name: Configure and Build Fuzz Targets
+        run: |
+          cmake -S . -B build-fuzz -G Ninja \
+            -DBUILD_TESTING=y -DCONFIG_BUILD_FUZZERS=y \
+            -DCONFIG_USE_UTILS=y -DCONFIG_USE_SYSTEM_HEAP=y
+          cmake --build build-fuzz
+        env:
+          CC: clang
+
+      - name: Replay Seed Corpora
+        run: cd build-fuzz && ctest --output-on-failure -R '_corpus$'
+
+  # Coverage-guided fuzzing of the APDU and profile parsers.
+  #
+  # Deliberately not run on ordinary PRs: a time-boxed search either repeats
+  # what the seed corpus already covers or reports something unrelated to the
+  # change under review. Ordinary PRs are covered by the fuzz-corpus job above,
+  # which replays the corpora deterministically in under a second. This search
+  # runs on the release-please PR and on manual dispatch.
+  #
+  # This job is informational -- do not add it to the required checks.
+  fuzz:
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' &&
+       startsWith(github.head_ref, 'release-please--branches--'))
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout Project
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Install CMake
+        uses: lukka/get-cmake@f5b8fbb4d77cec1acc5a5f9f0df4beffaf5d98d9 # v4.3.4
+        with:
+          cmakeVersion: 3.27.0
+          ninjaVersion: 1.11.1
+
+      - name: Install CLANG
+        # libclang-rt-*-dev carries the libFuzzer/ASan/UBSan runtimes. The
+        # hosted runner preinstalls them, but naming it keeps the job working
+        # on a bare container too. llvm-18 carries llvm-symbolizer, without
+        # which an ASan stack trace is hex addresses and no source lines.
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang libclang-rt-18-dev llvm-18
+
+      - name: Configure and Build Fuzz Targets
+        run: |
+          cmake -S . -B build-fuzz -G Ninja \
+            -DBUILD_TESTING=y -DCONFIG_BUILD_FUZZERS=y \
+            -DCONFIG_USE_UTILS=y -DCONFIG_USE_SYSTEM_HEAP=y
+          cmake --build build-fuzz
+        env:
+          CC: clang
+
+      - name: Fuzz
+        run: |
+          set -e
+          mkdir -p artifacts
+          F=build-fuzz/tests/fuzz
+          # -max_len per target: a T=0 TPDU is at most 261 bytes, and a profile
+          # string carrying every tag is 326 characters (include/onomondo/utils/ss_profile.h).
+          run() { "$F/$1" "$F/corpus/$2" -max_total_time="$3" -max_len="$4" \
+                    -artifact_prefix="$PWD/artifacts/$1-"; }
+          run fuzz_apdu_t0  apdu    600 261
+          run fuzz_apdu_app apdu    600 261
+          run fuzz_profile  profile 120 512
+
+      - name: Upload reproducers
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: fuzz-reproducers
+          path: artifacts/
+          if-no-files-found: ignore

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -104,9 +104,10 @@ jobs:
           # string carrying every tag is 326 characters (include/onomondo/utils/ss_profile.h).
           run() { "$F/$1" "$F/corpus/$2" -max_total_time="$3" -max_len="$4" \
                     -artifact_prefix="$PWD/artifacts/$1-"; }
-          run fuzz_apdu_t0  apdu    600 261
-          run fuzz_apdu_app apdu    600 261
-          run fuzz_profile  profile 120 512
+          run fuzz_apdu_t0    apdu    600 261
+          run fuzz_apdu_app   apdu    600 261
+          run fuzz_apdu_parse apdu    120 300
+          run fuzz_profile    profile 120 512
 
       - name: Upload reproducers
         if: ${{ failure() }}

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ lib_*.a
 targets
 .editorconfig
 *.py
+!tests/fuzz/gen_corpus.py
 
 # clang-format
 .cache

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,7 @@ option(CONFIG_NO_DEFAULT_IMPL 	"Build with no default implementation")
 option(CONFIG_COMPACT_STORAGE 	"Build with compact storage implementation")
 option(CONFIG_BUILD_LIB_ONLY 	"Build libraries only")
 option(CONFIG_ALT_FILE_SEPARATOR "Use _ as file separator instead of /")
+option(CONFIG_BUILD_FUZZERS 	"Build libFuzzer targets in tests/fuzz (clang only, implies sanitizers)")
 
 set(CONFIG_SS_STORAGE_PATH_DEFAULT "./files" CACHE STRING "Default storage path for SoftSIM filesystem")
 set(CONFIG_SS_STORAGE_PATH_MAX "100" CACHE STRING "Maximum path length for storage operations")
@@ -61,7 +62,20 @@ if(CONFIG_EXTERNAL_KEY_LOAD)
 	add_compile_definitions(CONFIG_EXTERNAL_KEY_LOAD)
 endif()
 
-if(CONFIG_ENABLE_SANITIZE)
+if(CONFIG_BUILD_FUZZERS)
+	if(NOT CMAKE_C_COMPILER_ID MATCHES "Clang")
+		message(FATAL_ERROR "CONFIG_BUILD_FUZZERS needs clang for libFuzzer. Re-run with CC=clang.")
+	endif()
+	# Instrument every translation unit so the fuzzer gets coverage feedback
+	# from the library under test, but link libFuzzer's main() only into the
+	# fuzz targets themselves (tests/fuzz adds -fsanitize=fuzzer there).
+	message(STATUS "Building libFuzzer targets (implies address/undefined sanitizers)")
+	# -fno-sanitize-recover makes UBSan abort rather than print and continue;
+	# without it a "runtime error:" line scrolls past and the run exits 0.
+	add_compile_options(-fsanitize=fuzzer-no-link,address,undefined -fno-sanitize-recover=undefined
+			    -fno-omit-frame-pointer -g)
+	add_link_options(-fsanitize=address,undefined -fno-sanitize-recover=undefined)
+elseif(CONFIG_ENABLE_SANITIZE)
 	add_compile_options(-fsanitize=address -fsanitize=undefined)
 	add_link_options(-fsanitize=address -fsanitize=undefined)
 endif()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -26,3 +26,7 @@ add_subdirectory(init)
 
 add_test(NAME sfi_check COMMAND sh ${CMAKE_CURRENT_SOURCE_DIR}/sfi_check.sh)
 add_subdirectory(key_scrub)
+
+if(CONFIG_BUILD_FUZZERS)
+	add_subdirectory(fuzz)
+endif()

--- a/tests/fuzz/CMakeLists.txt
+++ b/tests/fuzz/CMakeLists.txt
@@ -1,0 +1,69 @@
+# Copyright (c) 2026 Onomondo ApS. All rights reserved.
+# SPDX-License-Identifier: GPL-3.0-only
+
+# libFuzzer targets. Enabled with -DCONFIG_BUILD_FUZZERS=y (clang only).
+#
+# Each binary serves two purposes:
+#   ctest   `<target> <corpus> -runs=0` replays the seed corpus and exits. It is
+#           deterministic and sub-second, so it runs on every PR and turns a
+#           fixed crash into a permanent regression test.
+#   CI job  `<target> <corpus> -max_total_time=N` does the actual searching, and
+#           is gated to release branches, manual dispatch and the weekly cron.
+#           See the `fuzz` job in .github/workflows/ci_uicc.yml.
+
+find_package(Python3 REQUIRED COMPONENTS Interpreter)
+
+set(corpus_dir ${CMAKE_CURRENT_BINARY_DIR}/corpus)
+
+add_custom_command(
+	OUTPUT ${corpus_dir}/.stamp
+	COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/gen_corpus.py
+			--init-test ${PROJECT_SOURCE_DIR}/tests/init/init_test.c
+			--out ${corpus_dir}
+	COMMAND ${CMAKE_COMMAND} -E touch ${corpus_dir}/.stamp
+	DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/gen_corpus.py
+			${PROJECT_SOURCE_DIR}/tests/init/init_test.c
+	COMMENT "Generating fuzz seed corpus"
+	VERBATIM
+)
+add_custom_target(fuzz_corpus DEPENDS ${corpus_dir}/.stamp)
+
+# -fsanitize=fuzzer is added per target; the coverage instrumentation the
+# fuzzer feeds on is applied tree-wide by the top-level CMakeLists.
+function(add_fuzz_target name source corpus)
+	add_executable(${name} ${source})
+	target_include_directories(${name} PRIVATE ${PROJECT_SOURCE_DIR} ${PROJECT_SOURCE_DIR}/include)
+	target_compile_options(${name} PRIVATE -fsanitize=fuzzer)
+	target_link_options(${name} PRIVATE -fsanitize=fuzzer)
+	add_dependencies(${name} fuzz_corpus)
+
+	add_test(NAME ${name}_corpus COMMAND ${name} ${corpus_dir}/${corpus} -runs=0)
+endfunction()
+
+# ss_transact() and ss_application_apdu_transact() share a signature but not a
+# parser, so the same harness covers both.
+foreach(entry IN ITEMS ss_transact ss_application_apdu_transact)
+	if(entry STREQUAL "ss_transact")
+		set(target fuzz_apdu_t0)
+	else()
+		set(target fuzz_apdu_app)
+	endif()
+
+	add_fuzz_target(${target} fuzz_apdu.c apdu)
+	target_compile_definitions(${target} PRIVATE
+		FUZZ_ENTRY=${entry}
+		SS_FUZZ_FILES_SRC="${PROJECT_SOURCE_DIR}/files"
+	)
+	# Order matters: these are plain static archives with no declared
+	# interdependencies, and milenage pulls aes_128_encrypt_block out of
+	# crypto. Same order as tests/init.
+	target_link_libraries(${target} PRIVATE uicc milenage crypto storage)
+endforeach()
+
+# The profile parser lives in the utils library, which is optional.
+if(TARGET utils)
+	add_fuzz_target(fuzz_profile fuzz_profile.c profile)
+	target_link_libraries(fuzz_profile PRIVATE utils uicc)
+else()
+	message(STATUS "Fuzz: skipping fuzz_profile (needs -DCONFIG_USE_UTILS=y)")
+endif()

--- a/tests/fuzz/CMakeLists.txt
+++ b/tests/fuzz/CMakeLists.txt
@@ -66,6 +66,11 @@ foreach(entry IN ITEMS ss_transact ss_application_apdu_transact)
 	target_link_libraries(${target} PRIVATE uicc milenage crypto storage)
 endforeach()
 
+# The wire-format parser itself: both entry points truncate requests before
+# parsing, so the extended-Lc arithmetic past 260 bytes is only reachable here.
+add_fuzz_target(fuzz_apdu_parse fuzz_apdu_parse.c apdu)
+target_link_libraries(fuzz_apdu_parse PRIVATE uicc)
+
 # The profile parser lives in the utils library, which is optional.
 if(TARGET utils)
 	add_fuzz_target(fuzz_profile fuzz_profile.c profile)

--- a/tests/fuzz/CMakeLists.txt
+++ b/tests/fuzz/CMakeLists.txt
@@ -8,8 +8,8 @@
 #           deterministic and sub-second, so it runs on every PR and turns a
 #           fixed crash into a permanent regression test.
 #   CI job  `<target> <corpus> -max_total_time=N` does the actual searching, and
-#           is gated to release branches, manual dispatch and the weekly cron.
-#           See the `fuzz` job in .github/workflows/ci_uicc.yml.
+#           is gated to the release-please PR and manual dispatch.
+#           See the `fuzz` job in .github/workflows/fuzz.yml.
 
 find_package(Python3 REQUIRED COMPONENTS Interpreter)
 

--- a/tests/fuzz/CMakeLists.txt
+++ b/tests/fuzz/CMakeLists.txt
@@ -15,14 +15,20 @@ find_package(Python3 REQUIRED COMPONENTS Interpreter)
 
 set(corpus_dir ${CMAKE_CURRENT_BINARY_DIR}/corpus)
 
+# init_test.c is the short-form modem transcript; app_transact_test.c carries the
+# extended-length encodings. Both are DEPENDS so the corpus regenerates when
+# either transcript changes.
+set(init_transcript ${PROJECT_SOURCE_DIR}/tests/init/init_test.c)
+set(app_transcript ${PROJECT_SOURCE_DIR}/tests/app_transact/app_transact_test.c)
+
 add_custom_command(
 	OUTPUT ${corpus_dir}/.stamp
 	COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/gen_corpus.py
-			--init-test ${PROJECT_SOURCE_DIR}/tests/init/init_test.c
+			--transcript ${init_transcript}
+			--transcript ${app_transcript}
 			--out ${corpus_dir}
 	COMMAND ${CMAKE_COMMAND} -E touch ${corpus_dir}/.stamp
-	DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/gen_corpus.py
-			${PROJECT_SOURCE_DIR}/tests/init/init_test.c
+	DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/gen_corpus.py ${init_transcript} ${app_transcript}
 	COMMENT "Generating fuzz seed corpus"
 	VERBATIM
 )

--- a/tests/fuzz/README.md
+++ b/tests/fuzz/README.md
@@ -11,11 +11,11 @@ Not built by default. Requires clang.
 | Mode | Command | When |
 |---|---|---|
 | Corpus replay | `<target> <corpus> -runs=0` | Every PR, as `ctest` cases `fuzz_*_corpus`. Deterministic, well under a second. A fixed crash whose reproducer is in the corpus stays fixed. |
-| Searching | `<target> <corpus> -max_total_time=N` | The release-please release PR, the weekly cron and manual dispatch. See the `fuzz` job in `.github/workflows/ci_uicc.yml`. |
+| Searching | `<target> <corpus> -max_total_time=N` | The release-please release PR and manual dispatch. See the `fuzz` job in `.github/workflows/fuzz.yml`. |
 
 Fuzzing on every PR buys nothing: the run is time-boxed, so it either repeats
 what the corpus already covers or reports something unrelated to the change
-under review. The calibration follows zcbor's.
+under review.
 
 ## Running it
 
@@ -64,9 +64,13 @@ Both APDU harnesses share `fuzz_apdu.c`, compiled once per entry point with
 `-DFUZZ_ENTRY=<symbol>`; the two functions take the same arguments but do not
 share a parser.
 
-The seed corpus is generated at build time by `gen_corpus.py` from the modem
-initialisation transcript in `tests/init/init_test.c`, so it tracks that
-transcript rather than drifting from it.
+The seed corpus is generated at build time by `gen_corpus.py` from two
+transcripts the suite already maintains, so it tracks them rather than drifting
+from them: `tests/init/init_test.c` for short-form modem initialisation, and
+`tests/app_transact/app_transact_test.c` for the extended-length encodings.
+Extended length is selected by a single zero byte at offset 4, so an extended
+seed is what puts `fuzz_apdu_app` inside those branches from the first
+execution instead of leaving it to find the encoding by mutation.
 
 ## Known limits
 

--- a/tests/fuzz/README.md
+++ b/tests/fuzz/README.md
@@ -1,0 +1,83 @@
+# Fuzz targets
+
+libFuzzer harnesses for the parsers that sit on a trust boundary: the two APDU
+entry points (bytes from the modem) and the provisioning profile blob (bytes
+from a factory tool, an AT command or a FOTA payload).
+
+Not built by default. Requires clang.
+
+## Two modes, one binary
+
+| Mode | Command | When |
+|---|---|---|
+| Corpus replay | `<target> <corpus> -runs=0` | Every PR, as `ctest` cases `fuzz_*_corpus`. Deterministic, well under a second. A fixed crash whose reproducer is in the corpus stays fixed. |
+| Searching | `<target> <corpus> -max_total_time=N` | The release-please release PR, the weekly cron and manual dispatch. See the `fuzz` job in `.github/workflows/ci_uicc.yml`. |
+
+Fuzzing on every PR buys nothing: the run is time-boxed, so it either repeats
+what the corpus already covers or reports something unrelated to the change
+under review. The calibration follows zcbor's.
+
+## Running it
+
+Everything runs in a container.
+
+```sh
+docker run --rm -v "$PWD:/src:ro" -v /tmp/ssfuzz:/out -e CC=clang \
+  -w /src ubuntu:24.04 bash -c '
+    apt-get update && apt-get install -y cmake ninja-build clang libclang-rt-18-dev llvm-18 python3
+    cmake -S /src -B /out/build -G Ninja \
+      -DBUILD_TESTING=y -DCONFIG_BUILD_FUZZERS=y -DCONFIG_USE_UTILS=y -DCONFIG_USE_SYSTEM_HEAP=y
+    cmake --build /out/build
+    cd /out/build && ctest --output-on-failure -R "_corpus\$"   # corpus replay
+    ./tests/fuzz/fuzz_apdu_t0 ./tests/fuzz/corpus/apdu -max_total_time=600 -max_len=261
+  '
+```
+
+`libclang-rt-18-dev` is not optional: `apt-get install clang` alone ships no
+sanitizer runtimes, and the link fails with `libclang_rt.asan-<arch>.a: No such
+file`. The GitHub `ubuntu-24.04` runner happens to preinstall them, a plain
+container does not.
+
+`llvm-18` carries `llvm-symbolizer`. Without it an ASan report is frame
+addresses and `BuildId` lines with no function or source location, which makes
+a finding almost impossible to triage. UBSan is unaffected -- it embeds the
+source location at compile time.
+
+Pass `-artifact_prefix=<dir>/` when searching. Without it libFuzzer drops
+`crash-*` / `leak-*` reproducer files into the current directory, which is
+usually the repository.
+
+A search also writes every input it keeps back into the first corpus directory
+on its command line, so searching `corpus/apdu` directly grows the seed set the
+`ctest` replay then reads. Copy the directory first if you want the replay to
+keep replaying the generated seeds and nothing else.
+
+## Targets
+
+| Target | Entry point | Notes |
+|---|---|---|
+| `fuzz_apdu_t0` | `ss_transact()` | The T=0 / VPCD path. Copies a fixed-size header. |
+| `fuzz_apdu_app` | `ss_application_apdu_transact()` | The path the nRF modem glue calls. Parses via `ss_apdu_parse_exhaustive()`. |
+| `fuzz_profile` | `ss_profile_from_string()` | Needs `-DCONFIG_USE_UTILS=y`. |
+
+Both APDU harnesses share `fuzz_apdu.c`, compiled once per entry point with
+`-DFUZZ_ENTRY=<symbol>`; the two functions take the same arguments but do not
+share a parser.
+
+The seed corpus is generated at build time by `gen_corpus.py` from the modem
+initialisation transcript in `tests/init/init_test.c`, so it tracks that
+transcript rather than drifting from it.
+
+## Known limits
+
+- **The staged EF tree is shared between executions.** Each input gets a fresh
+  `ss_context`, but the on-disk filesystem persists for the life of the
+  process, so a crash that depends on an earlier input having written to it
+  will not replay standalone. The upgrade path is an in-memory storage backend
+  behind `CONFIG_NO_DEFAULT_IMPL`.
+- **LeakSanitizer only exists on Linux.** Leak findings will never appear on a
+  macOS host; this is one of the reasons the workflow is container-only.
+- **If ASan aborts at startup** with `Shadow memory range interleaves with an
+  existing memory mapping`, that is the Ubuntu 24.04 ASLR entropy clash, not a
+  bug in the harness. Run the container with `--privileged`, or set
+  `vm.mmap_rnd_bits=28` in the Docker VM.

--- a/tests/fuzz/README.md
+++ b/tests/fuzz/README.md
@@ -58,11 +58,23 @@ keep replaying the generated seeds and nothing else.
 |---|---|---|
 | `fuzz_apdu_t0` | `ss_transact()` | The T=0 / VPCD path. Copies a fixed-size header. |
 | `fuzz_apdu_app` | `ss_application_apdu_transact()` | The path the nRF modem glue calls. Parses via `ss_apdu_parse_exhaustive()`. |
+| `fuzz_apdu_parse` | `ss_apdu_parse_exhaustive()` | The wire-format parser directly, no card behind it. |
 | `fuzz_profile` | `ss_profile_from_string()` | Needs `-DCONFIG_USE_UTILS=y`. |
 
 Both APDU harnesses share `fuzz_apdu.c`, compiled once per entry point with
 `-DFUZZ_ENTRY=<symbol>`; the two functions take the same arguments but do not
 share a parser.
+
+`fuzz_apdu_parse` exists because the entry points truncate requests to 260
+bytes before parsing, so no input driven through them can reach the parser's
+extended-Lc arithmetic past that limit -- `Lc = 257` (a 264-byte request) is
+the first length that clears the data-field bound and would overrun `cmd[]`.
+That overrun lands in `rsp[]`, the adjacent member of the same struct, so ASan
+never faults on it; the harness instead asserts two post-conditions after each
+parse: `lc` fits `cmd[]`, and `processed_bytes` does not exceed the request.
+The corpus pins witnesses at the boundary lengths (over-claiming short Lc at
+6-10 bytes, extended Lc 255/256/257 at 262-264 bytes), so weakening either
+guard in the parser fails the deterministic corpus replay on the next PR.
 
 The seed corpus is generated at build time by `gen_corpus.py` from two
 transcripts the suite already maintains, so it tracks them rather than drifting

--- a/tests/fuzz/fuzz_apdu.c
+++ b/tests/fuzz/fuzz_apdu.c
@@ -34,7 +34,7 @@
  * truncate anything longer, so larger inputs only cost the fuzzer time. */
 #define MAX_APDU 261
 
-/* Both entry points assert response_buf_len >= sizeof(apdu->rsp) + sizeof(apdu->sw), i.e. 258. */
+/* Both entry points reject response_buf_len < sizeof(apdu->rsp) + sizeof(apdu->sw), i.e. 258. */
 #define RESP_LEN 512
 
 static char storage_dir[] = "/tmp/ss_fuzz_XXXXXX";
@@ -80,11 +80,8 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 		return 0;
 	}
 
-	/* The entry points take a mutable buffer, so hand them a copy rather than
-	 * libFuzzer's. Heap, and exactly `size` bytes: a parser that reads one
-	 * byte past the request is then an ASan report rather than a silent read
-	 * of adjacent stack. That distinction is exactly what the existing tests
-	 * miss -- they pass string literals and oversized arrays. */
+	/* Exact-size heap copy (the entry points mutate the buffer): a one-byte
+	 * over-read becomes an ASan report instead of a silent read. */
 	req = malloc(size ? size : 1); /* malloc(0) may be NULL, which would skip the empty seed */
 	if (!req) {
 		return 0;
@@ -92,10 +89,8 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 	memcpy(req, data, size);
 	req_len = size;
 
-	/* A fresh context per input keeps executions independent. The staged EF
-	 * tree is shared across them, so a crash that depends on an earlier input
-	 * having written to it does not replay standalone -- see "Known limits"
-	 * in README.md. */
+	/* Fresh context per input; the staged EF tree is shared across
+	 * executions -- see "Known limits" in README.md. */
 	ctx = ss_new_ctx();
 	if (ctx) {
 		ss_reset(ctx);

--- a/tests/fuzz/fuzz_apdu.c
+++ b/tests/fuzz/fuzz_apdu.c
@@ -85,7 +85,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 	 * byte past the request is then an ASan report rather than a silent read
 	 * of adjacent stack. That distinction is exactly what the existing tests
 	 * miss -- they pass string literals and oversized arrays. */
-	req = malloc(size);
+	req = malloc(size ? size : 1); /* malloc(0) may be NULL, which would skip the empty seed */
 	if (!req) {
 		return 0;
 	}

--- a/tests/fuzz/fuzz_apdu.c
+++ b/tests/fuzz/fuzz_apdu.c
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2026 Onomondo ApS. All rights reserved.
+ *
+ * SPDX-License-Identifier: GPL-3.0-only
+ *
+ * libFuzzer harness for the byte-in/byte-out APDU entry points.
+ *
+ * ss_transact() and ss_application_apdu_transact() take the same arguments but
+ * parse differently -- the former copies a fixed-size header, the latter runs
+ * ss_apdu_parse_exhaustive() -- so this file is compiled once per entry point
+ * with -DFUZZ_ENTRY=<symbol> rather than duplicated.
+ *
+ * This is the modem-facing trust boundary: every byte reaching it comes from
+ * outside the card.
+ */
+
+#include <onomondo/softsim/softsim.h>
+#include <onomondo/softsim/storage.h>
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#ifndef FUZZ_ENTRY
+#error "define FUZZ_ENTRY to ss_transact or ss_application_apdu_transact"
+#endif
+
+#ifndef SS_FUZZ_FILES_SRC
+#error "define SS_FUZZ_FILES_SRC to the EF tree to stage"
+#endif
+
+/* T=0 tops out at a 5-byte header plus a 256-byte body. Both entry points
+ * truncate anything longer, so larger inputs only cost the fuzzer time. */
+#define MAX_APDU 261
+
+/* Both entry points assert response_buf_len >= sizeof(apdu->rsp) + sizeof(apdu->sw), i.e. 258. */
+#define RESP_LEN 512
+
+static char storage_dir[] = "/tmp/ss_fuzz_XXXXXX";
+
+/* Stage a private copy of the EF tree so the fuzzer never writes into the
+ * repository (the in-tree ctest suites do, which is a known annoyance) and so
+ * concurrent jobs cannot corrupt each other. */
+int LLVMFuzzerInitialize(int *argc, char ***argv)
+{
+	char cmd[2 * SS_STORAGE_PATH_MAX + sizeof(SS_FUZZ_FILES_SRC) + 32];
+
+	(void)argc;
+	(void)argv;
+
+	if (!mkdtemp(storage_dir)) {
+		perror("mkdtemp");
+		abort();
+	}
+
+	/* The tree is staged exactly once per process, so cp -R carries it. */
+	snprintf(cmd, sizeof(cmd), "cp -R '%s/.' '%s/'", SS_FUZZ_FILES_SRC, storage_dir);
+	if (system(cmd) != 0) {
+		fprintf(stderr, "fuzz: failed to stage EF tree from %s\n", SS_FUZZ_FILES_SRC);
+		abort();
+	}
+
+	if (ss_storage_set_path(storage_dir) != 0) {
+		fprintf(stderr, "fuzz: ss_storage_set_path(%s) failed\n", storage_dir);
+		abort();
+	}
+
+	return 0;
+}
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+{
+	struct ss_context *ctx;
+	uint8_t resp[RESP_LEN];
+	uint8_t *req;
+	size_t req_len;
+
+	if (size > MAX_APDU) {
+		return 0;
+	}
+
+	/* The entry points take a mutable buffer, so hand them a copy rather than
+	 * libFuzzer's. Heap, and exactly `size` bytes: a parser that reads one
+	 * byte past the request is then an ASan report rather than a silent read
+	 * of adjacent stack. That distinction is exactly what the existing tests
+	 * miss -- they pass string literals and oversized arrays. */
+	req = malloc(size);
+	if (!req) {
+		return 0;
+	}
+	memcpy(req, data, size);
+	req_len = size;
+
+	/* A fresh context per input keeps executions independent. The staged EF
+	 * tree is shared across them, so a crash that depends on an earlier input
+	 * having written to it does not replay standalone -- see "Known limits"
+	 * in README.md. */
+	ctx = ss_new_ctx();
+	if (ctx) {
+		ss_reset(ctx);
+		FUZZ_ENTRY(ctx, resp, sizeof(resp), req, &req_len);
+		ss_free_ctx(ctx);
+	}
+
+	free(req);
+
+	return 0;
+}

--- a/tests/fuzz/fuzz_apdu_parse.c
+++ b/tests/fuzz/fuzz_apdu_parse.c
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2026 Onomondo ApS. All rights reserved.
+ *
+ * SPDX-License-Identifier: GPL-3.0-only
+ *
+ * libFuzzer harness for the APDU wire-format parser itself.
+ *
+ * The entry-point harnesses (fuzz_apdu.c) can never exercise the parser past
+ * 260 bytes: ss_transact() and ss_application_apdu_transact() truncate longer
+ * requests before parsing. The extended-Lc arithmetic above that limit --
+ * where Lc = 257 clears the data-field bound but overruns cmd[] -- is only
+ * reachable by calling ss_apdu_parse_exhaustive() directly.
+ *
+ * The two post-conditions catch what ASan cannot: apdu->cmd and apdu->rsp are
+ * adjacent in one struct, so an over-long Lc writes past cmd[256] into rsp[]
+ * without leaving the object; and processed_bytes running past the request is
+ * a logic defect, not a memory error.
+ */
+
+#include "src/softsim/uicc/apdu.h"
+
+#include <assert.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#ifdef NDEBUG
+#error "the post-conditions are asserts; an NDEBUG build silently tests nothing"
+#endif
+
+/* Nothing branches on bytes past header + extended Lc + 256-byte body +
+ * extended Le trailer; longer inputs only cost the fuzzer time. */
+#define MAX_PARSE 300
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+{
+	struct ss_apdu apdu = { 0 };
+	uint8_t *req;
+
+	if (size > MAX_PARSE) {
+		return 0;
+	}
+
+	/* Exact-size heap copy: a one-byte over-read becomes an ASan report
+	 * instead of a silent read. */
+	req = malloc(size ? size : 1); /* malloc(0) may be NULL, which would skip the empty seed */
+	if (!req) {
+		return 0;
+	}
+	memcpy(req, data, size);
+
+	ss_apdu_parse_exhaustive(&apdu, req, size);
+
+	/* cmd[256] and rsp[256] are one allocation: an over-long Lc overflows cmd
+	 * into rsp without leaving the object, so the copy alone never faults. */
+	assert(apdu.lc <= sizeof(apdu.cmd));
+	/* the out: guard clamps both lc and processed_bytes to the request. */
+	assert(apdu.processed_bytes <= size);
+
+	free(req);
+
+	return 0;
+}

--- a/tests/fuzz/fuzz_profile.c
+++ b/tests/fuzz/fuzz_profile.c
@@ -26,10 +26,8 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 		return 0;
 	}
 
-	/* An exact-length heap copy is the entire point of this harness. Both
-	 * production call sites and every existing test hand the parser a string
-	 * literal or an oversized buffer, so a read past the declared length hits
-	 * adjacent readable memory and goes unnoticed. */
+	/* Exact-length heap copy: a read past the declared length becomes an
+	 * ASan report instead of a silent read of adjacent memory. */
 	input = malloc(size ? size : 1); /* malloc(0) may be NULL, which would skip the empty seed */
 	if (!input) {
 		return 0;

--- a/tests/fuzz/fuzz_profile.c
+++ b/tests/fuzz/fuzz_profile.c
@@ -30,7 +30,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 	 * production call sites and every existing test hand the parser a string
 	 * literal or an oversized buffer, so a read past the declared length hits
 	 * adjacent readable memory and goes unnoticed. */
-	input = malloc(size);
+	input = malloc(size ? size : 1); /* malloc(0) may be NULL, which would skip the empty seed */
 	if (!input) {
 		return 0;
 	}

--- a/tests/fuzz/fuzz_profile.c
+++ b/tests/fuzz/fuzz_profile.c
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2026 Onomondo ApS. All rights reserved.
+ *
+ * SPDX-License-Identifier: GPL-3.0-only
+ *
+ * libFuzzer harness for the provisioning profile blob parser.
+ *
+ * ss_profile_from_string() is a trust boundary: the blob arrives from a
+ * factory tool, an AT command or a FOTA payload, and a corrupted one must be
+ * rejected rather than mis-parsed.
+ */
+
+#include <onomondo/utils/ss_profile.h>
+
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+{
+	struct ss_profile profile = { 0 };
+	char *input;
+
+	/* The length parameter is uint16_t; anything longer cannot be expressed. */
+	if (size > UINT16_MAX) {
+		return 0;
+	}
+
+	/* An exact-length heap copy is the entire point of this harness. Both
+	 * production call sites and every existing test hand the parser a string
+	 * literal or an oversized buffer, so a read past the declared length hits
+	 * adjacent readable memory and goes unnoticed. */
+	input = malloc(size);
+	if (!input) {
+		return 0;
+	}
+	memcpy(input, data, size);
+
+	ss_profile_from_string((uint16_t)size, input, &profile);
+
+	free(input);
+
+	return 0;
+}

--- a/tests/fuzz/gen_corpus.py
+++ b/tests/fuzz/gen_corpus.py
@@ -53,6 +53,14 @@ def apdu_seeds(transcripts):
     # Boundary lengths around the fixed 5-byte header copy in ss_transact().
     # Cheap to include and they are where the length arithmetic goes wrong.
     seeds += [b"", b"\x00", b"\x00\xa4\x00\x0c", b"\x00\xa4\x00\x0c\x02"]
+
+    # Witnesses for fuzz_apdu_parse's post-conditions. Short Case 3/4 requests
+    # whose Lc over-claims the buffer pin the processed_bytes clamp (len 6-10);
+    # extended-Lc requests at the exact fit and one past it (Lc 255/256/257,
+    # len 262/263/264) pin the cmd[] bound. The entry-point targets truncate
+    # the long ones, which is harmless.
+    seeds += [b"\xff\xff\xff\xff" + bytes([lc]) + b"\xff" * (lc - 1) for lc in range(2, 7)]
+    seeds += [b"\x00\xa4\x00\x04\x00" + lc.to_bytes(2, "big") + b"\xff" * lc for lc in (255, 256, 257)]
     return seeds
 
 

--- a/tests/fuzz/gen_corpus.py
+++ b/tests/fuzz/gen_corpus.py
@@ -12,11 +12,8 @@ including the STATUS with an extended Le that the nRF9151 sends. The profile
 seeds are built from the TLV layout documented in
 include/onomondo/utils/ss_profile.h.
 
-A seed corpus is not decoration: without one the fuzzer spends its budget
-rediscovering that APDUs start with a class byte, and never reaches the file
-operations behind SELECT. Extended length is keyed on a single zero byte at
-offset 4, so without an extended seed the fuzzer has to stumble onto that
-encoding before it can explore anything behind it.
+Without a seed corpus the fuzzer spends its budget rediscovering the wire
+format instead of exploring behind it; see README.md for the rationale.
 """
 
 import argparse
@@ -24,8 +21,9 @@ import hashlib
 import pathlib
 import re
 
-# Quoted, even-length, pure-hex string literals. In these transcripts that is
-# exactly the apdus[] arrays; format strings and byte arrays do not match.
+# Quoted, even-length, pure-hex string literals. In these transcripts those are
+# all APDU vectors (the apdus[] arrays plus init_test.c's short-APDU cases);
+# format strings and byte arrays do not match.
 HEX_LITERAL = re.compile(r'"((?:[0-9a-fA-F]{2})+)"')
 
 

--- a/tests/fuzz/gen_corpus.py
+++ b/tests/fuzz/gen_corpus.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Onomondo ApS. All rights reserved.
+# SPDX-License-Identifier: GPL-3.0-only
+
+"""Generate libFuzzer seed corpora.
+
+The APDU seeds are lifted from the modem-initialisation transcript that
+tests/init/init_test.c already maintains, so the corpus tracks the transcript
+instead of drifting from it. The profile seeds are built from the TLV layout
+documented in include/onomondo/utils/ss_profile.h.
+
+A seed corpus is not decoration: without one the fuzzer spends its budget
+rediscovering that APDUs start with a class byte, and never reaches the file
+operations behind SELECT.
+"""
+
+import argparse
+import hashlib
+import pathlib
+import re
+
+# Quoted, even-length, pure-hex string literals. In init_test.c that is exactly
+# the apdus[] array; log format strings and byte arrays do not match.
+HEX_LITERAL = re.compile(r'"((?:[0-9a-fA-F]{2})+)"')
+
+
+def write_seeds(out_dir, blobs):
+    """Write one file per distinct blob, named by content hash."""
+    out_dir.mkdir(parents=True, exist_ok=True)
+    for stale in out_dir.glob("*.bin"):
+        stale.unlink()
+
+    written = 0
+    for blob in {bytes(b) for b in blobs}:
+        name = hashlib.sha1(blob).hexdigest()[:16] + ".bin"
+        (out_dir / name).write_bytes(blob)
+        written += 1
+    return written
+
+
+def apdu_seeds(init_test):
+    text = pathlib.Path(init_test).read_text()
+    seeds = [bytes.fromhex(m) for m in HEX_LITERAL.findall(text)]
+    if not seeds:
+        raise SystemExit(f"{init_test}: no APDU hex literals found -- has the transcript moved?")
+
+    # Boundary lengths around the fixed 5-byte header copy in ss_transact().
+    # Cheap to include and they are where the length arithmetic goes wrong.
+    seeds += [b"", b"\x00", b"\x00\xa4\x00\x0c", b"\x00\xa4\x00\x0c\x02"]
+    return seeds
+
+
+def profile_seeds():
+    def tlv(tag, payload):
+        # Both tag and length are themselves hex-encoded in this format.
+        return f"{tag:02x}{len(payload):02x}{payload}"
+
+    key = "000102030405060708090A0B0C0D0E0F"
+    complete = (
+        tlv(0x01, "080910101032540636")   # IMSI
+        + tlv(0x02, "98001032547698103214")  # ICCID
+        + tlv(0x03, "0" * 32)             # OPc
+        + tlv(0x04, key)                  # Ki
+        + tlv(0x05, key)                  # KIC
+        + tlv(0x06, key)                  # KID
+    )
+
+    return [
+        complete.encode(),
+        (complete + "ff00").encode(),          # explicit END tag
+        tlv(0x01, "080910101032540636").encode(),  # single record
+        b"",                                    # the degenerate length
+    ]
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--init-test", required=True)
+    ap.add_argument("--out", required=True, type=pathlib.Path)
+    args = ap.parse_args()
+
+    n_apdu = write_seeds(args.out / "apdu", apdu_seeds(args.init_test))
+    n_profile = write_seeds(args.out / "profile", profile_seeds())
+    print(f"fuzz corpus: {n_apdu} apdu seeds, {n_profile} profile seeds -> {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/fuzz/gen_corpus.py
+++ b/tests/fuzz/gen_corpus.py
@@ -4,14 +4,19 @@
 
 """Generate libFuzzer seed corpora.
 
-The APDU seeds are lifted from the modem-initialisation transcript that
-tests/init/init_test.c already maintains, so the corpus tracks the transcript
-instead of drifting from it. The profile seeds are built from the TLV layout
-documented in include/onomondo/utils/ss_profile.h.
+The APDU seeds are lifted from the transcripts the test suite already
+maintains, so the corpus tracks them instead of drifting from them:
+tests/init/init_test.c covers modem initialisation in short form, and
+tests/app_transact/app_transact_test.c carries the extended-length encodings,
+including the STATUS with an extended Le that the nRF9151 sends. The profile
+seeds are built from the TLV layout documented in
+include/onomondo/utils/ss_profile.h.
 
 A seed corpus is not decoration: without one the fuzzer spends its budget
 rediscovering that APDUs start with a class byte, and never reaches the file
-operations behind SELECT.
+operations behind SELECT. Extended length is keyed on a single zero byte at
+offset 4, so without an extended seed the fuzzer has to stumble onto that
+encoding before it can explore anything behind it.
 """
 
 import argparse
@@ -19,8 +24,8 @@ import hashlib
 import pathlib
 import re
 
-# Quoted, even-length, pure-hex string literals. In init_test.c that is exactly
-# the apdus[] array; log format strings and byte arrays do not match.
+# Quoted, even-length, pure-hex string literals. In these transcripts that is
+# exactly the apdus[] arrays; format strings and byte arrays do not match.
 HEX_LITERAL = re.compile(r'"((?:[0-9a-fA-F]{2})+)"')
 
 
@@ -38,11 +43,14 @@ def write_seeds(out_dir, blobs):
     return written
 
 
-def apdu_seeds(init_test):
-    text = pathlib.Path(init_test).read_text()
-    seeds = [bytes.fromhex(m) for m in HEX_LITERAL.findall(text)]
-    if not seeds:
-        raise SystemExit(f"{init_test}: no APDU hex literals found -- has the transcript moved?")
+def apdu_seeds(transcripts):
+    seeds = []
+    for transcript in transcripts:
+        text = pathlib.Path(transcript).read_text()
+        found = [bytes.fromhex(m) for m in HEX_LITERAL.findall(text)]
+        if not found:
+            raise SystemExit(f"{transcript}: no APDU hex literals found -- has the transcript moved?")
+        seeds += found
 
     # Boundary lengths around the fixed 5-byte header copy in ss_transact().
     # Cheap to include and they are where the length arithmetic goes wrong.
@@ -75,11 +83,12 @@ def profile_seeds():
 
 def main():
     ap = argparse.ArgumentParser()
-    ap.add_argument("--init-test", required=True)
+    ap.add_argument("--transcript", required=True, action="append", metavar="PATH",
+                    help="C file holding an apdus[] array of hex literals; repeatable")
     ap.add_argument("--out", required=True, type=pathlib.Path)
     args = ap.parse_args()
 
-    n_apdu = write_seeds(args.out / "apdu", apdu_seeds(args.init_test))
+    n_apdu = write_seeds(args.out / "apdu", apdu_seeds(args.transcript))
     n_profile = write_seeds(args.out / "profile", profile_seeds())
     print(f"fuzz corpus: {n_apdu} apdu seeds, {n_profile} profile seeds -> {args.out}")
 


### PR DESCRIPTION
Coverage-guided fuzzing for the three parsers that sit on a trust boundary: `ss_transact()` and
`ss_application_apdu_transact()` take bytes from the modem, `ss_profile_from_string()` takes a
provisioning blob. All behind `-DCONFIG_BUILD_FUZZERS=y` (clang only), so the normal build is
untouched.

Each binary does double duty. Under ctest it replays its seed corpus with `-runs=0` —
deterministic, sub-second, run on every PR by the new `fuzz-corpus` job, which is what turns a
fixed crash into a permanent regression test. The searching `fuzz` job is gated to the
release-please PR and manual dispatch, and stays informational: a finding is a report to triage,
not a broken build.
