### PR TITLE
refactor: remove unused ss_buf_hexdump

### DIFF
--- a/include/onomondo/softsim/utils.h
+++ b/include/onomondo/softsim/utils.h
@@ -21,16 +21,6 @@ struct ss_buf {
 	size_t len;
 };
 
-/*! Generate a hexdump string from an ss_buf object.
- *  \param[in] buf pointer to ss_buf object.
- *  \returns pointer to generated human readable string. */
-static inline char *ss_buf_hexdump(const struct ss_buf *buf)
-{
-	if (!buf)
-		return "(null)";
-	return ss_hexdump(buf->data, buf->len);
-}
-
 /*! Allocate a new ss_buf object.
  *  \param[in] len number of bytes to allocate inside ss_buf.
  *  \returns pointer to newly allocated ss_buf object. */


### PR DESCRIPTION
Removes `ss_buf_hexdump()` from `include/onomondo/softsim/utils.h`.

⚠️ **Public API removal — please veto if this is used out of tree.** `ss_buf_hexdump` is declared in a public header. 