### PR TITLE
refactor: give file-local helpers internal linkage

### DIFF
--- a/src/softsim/main.c
+++ b/src/softsim/main.c
@@ -132,7 +132,7 @@ static int handle_request(struct ss_context *ctx, int socket_fd)
 
 /* Subtract timeval y from x, see also:
  * https://www.gnu.org/software/libc/manual/html_node/Calculating-Elapsed-Time.html */
-int timeval_subtract(struct timeval *result, struct timeval *x, struct timeval *y)
+static int timeval_subtract(struct timeval *result, struct timeval *x, struct timeval *y)
 {
 	if (x->tv_usec < y->tv_usec) {
 		int nsec = (y->tv_usec - x->tv_usec) / 1000000 + 1;

--- a/src/softsim/uicc/access.c
+++ b/src/softsim/uicc/access.c
@@ -42,7 +42,7 @@ const uint8_t FCP_TAG_SECURITY_ATTRIB_COMPACT = 0x8c;
 const uint8_t FCP_TAG_SECURITY_ATTRIB_EXTENDED = 0xab;
 
 /** Extract the access rule reference from the FCP as described in TS 102 221 v15.0.0 Section 9.2.7 */
-struct arr_ref arr_from_fcp(struct ss_list *fcp_decoded_envelope)
+static struct arr_ref arr_from_fcp(struct ss_list *fcp_decoded_envelope)
 {
 	struct ber_tlv_ie *fcp_decoded_arr;
 

--- a/src/softsim/uicc/fs.c
+++ b/src/softsim/uicc/fs.c
@@ -39,7 +39,7 @@ static struct ss_file *path_add(struct ss_list *path, uint32_t fid)
 }
 
 /* Free a file struct and its contents. */
-void file_free(struct ss_file *file)
+static void file_free(struct ss_file *file)
 {
 	if (!file)
 		return;

--- a/src/softsim/uicc/uicc_cat.c
+++ b/src/softsim/uicc/uicc_cat.c
@@ -39,7 +39,7 @@ struct ss_cat_envelope_command {
 };
 
 /* Handler function to handle CAT SMS PP Download */
-int handle_sms_pp_dwnld(struct ss_apdu *apdu, struct ss_buf *cat_template)
+static int handle_sms_pp_dwnld(struct ss_apdu *apdu, struct ss_buf *cat_template)
 {
 	struct ss_list *ctlv_data = NULL;
 	struct cmp_tlv_ie *sms_tpdu_ie;

--- a/src/softsim/uicc/uicc_sms_tx.c
+++ b/src/softsim/uicc/uicc_sms_tx.c
@@ -72,7 +72,7 @@ void ss_uicc_sms_tx_clear(struct ss_context *ctx)
 }
 
 /* Encode a single short message TPDU */
-int encode_sm(uint8_t *sm_enc, size_t sm_enc_len, const struct ss_sm_hdr *sm_hdr, const uint8_t *ud_hdr,
+static int encode_sm(uint8_t *sm_enc, size_t sm_enc_len, const struct ss_sm_hdr *sm_hdr, const uint8_t *ud_hdr,
 	      size_t ud_hdr_len, const uint8_t *tp_ud, size_t tp_ud_len, bool recalc_tp_udl)
 {
 	int rc;
@@ -263,7 +263,7 @@ static uint8_t calc_message_parts(size_t ud_hdr_len, size_t tp_ud_len)
  * usually done to remove already scheduled parts of a concatenated SM from
  * the queue in case there is an error while generating and enqueing the
  * partial messages. */
-void cancel_sm(struct ss_uicc_sms_tx_state *state, uint8_t msg_id)
+static void cancel_sm(struct ss_uicc_sms_tx_state *state, uint8_t msg_id)
 {
 	struct ss_uicc_sms_tx_sm *sm;
 	struct ss_uicc_sms_tx_sm *sm_pre;

--- a/src/softsim/uicc/uicc_sms_tx.c
+++ b/src/softsim/uicc/uicc_sms_tx.c
@@ -73,7 +73,7 @@ void ss_uicc_sms_tx_clear(struct ss_context *ctx)
 
 /* Encode a single short message TPDU */
 static int encode_sm(uint8_t *sm_enc, size_t sm_enc_len, const struct ss_sm_hdr *sm_hdr, const uint8_t *ud_hdr,
-	      size_t ud_hdr_len, const uint8_t *tp_ud, size_t tp_ud_len, bool recalc_tp_udl)
+		     size_t ud_hdr_len, const uint8_t *tp_ud, size_t tp_ud_len, bool recalc_tp_udl)
 {
 	int rc;
 	size_t bytes_used = 0;

--- a/src/softsim/uicc/utils_3des.c
+++ b/src/softsim/uicc/utils_3des.c
@@ -11,7 +11,7 @@
 #include <onomondo/softsim/crypto.h>
 
 #ifndef CONFIG_EXTERNAL_CRYPTO_IMPL
-void setup_key(const uint8_t *src, struct des3_key_s *dest)
+static void setup_key(const uint8_t *src, struct des3_key_s *dest)
 {
 	/* The library wants keys in 24byte form, but we have the 16byte form */
 	/* If the compiler is smart, that doesn't really happen (but things re


### PR DESCRIPTION
Seven helpers are defined without `static`, are declared in no header, and are referenced only from inside their own translation unit — so they were exported from `libuicc`, where they can collide with an integrator's symbols and where the compiler cannot inline or dead-strip them.