### PR TITLE
test: run init_test from a private copy of files/

### DIFF
--- a/tests/app_transact/CMakeLists.txt
+++ b/tests/app_transact/CMakeLists.txt
@@ -8,7 +8,7 @@ include_directories(${PROJECT_SOURCE_DIR}/include)
 target_link_libraries(app_apdu_test uicc milenage crypto storage $<$<TARGET_EXISTS:utils>:utils>)
 
 # Snapshot files/ at configure time, as tests/key_scrub does: suites that run
-# from the source root (tests/init, tests/pin) write into ${CMAKE_SOURCE_DIR}/files
+# from the source root (tests/pin, tests/utils) write into ${CMAKE_SOURCE_DIR}/files
 # during the run, so a copy taken while ctest is running can capture their edits.
 file(COPY ${CMAKE_SOURCE_DIR}/files DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/pristine)
 

--- a/tests/init/CMakeLists.txt
+++ b/tests/init/CMakeLists.txt
@@ -10,11 +10,11 @@ target_link_libraries(init_test uicc milenage crypto storage $<$<TARGET_EXISTS:u
 
 add_test(NAME init_test COMMAND sh -c "$<TARGET_FILE:init_test> > ${CMAKE_CURRENT_BINARY_DIR}/init_test.out")
 
-# Ensure the test runs from the project root so relative storage-path './files'
-# resolves to the repository 'files' directory (where 3f00.def lives). This
-# avoids needing embedded static files or runtime environment changes for
-# tests that read the host filesystem.
-set_tests_properties(init_test PROPERTIES WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+# The suite reads and writes ./files, so it runs on a private copy of the
+# filesystem instead of the one in the source tree.
+file(COPY ${CMAKE_SOURCE_DIR}/files DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
+
+set_tests_properties(init_test PROPERTIES WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 
 add_test(NAME init_test_compare
 	 COMMAND ${CMAKE_COMMAND} -E compare_files --ignore-eol


### PR DESCRIPTION
init_test drove the card against the tracked `files/` tree, because the storage backend resolves `"./files"` against the working directory and ctest set that to the source root. Snapshot `files/` at configure time and run from the binary directory, as `tests/read_binary`, `tests/envelope`, `tests/app_transact` and `tests/key_scrub` already do.