### PR TITLE
fix: reset the PIN retry counter after a successful CHANGE PIN

### DIFF
--- a/src/softsim/uicc/uicc_pin.c
+++ b/src/softsim/uicc/uicc_pin.c
@@ -299,8 +299,10 @@ int ss_uicc_pin_cmd_change_pin(struct ss_apdu *apdu)
 		goto leave;
 	}
 
-	/* Apply new PIN code */
+	/* Apply new PIN code. A successful verification of the old PIN resets
+	 * the retry counter, as it does for VERIFY PIN. */
 	memcpy(pin->pin, apdu->cmd + sizeof(pin->pin), sizeof(pin->pin));
+	pin->tries = 0;
 	rc = update_pin_context(pin);
 	if (rc < 0) {
 		result = SS_SW_ERR_CMD_NOT_ALLOWED_PIN_BLOCKED;

--- a/tests/pin/CMakeLists.txt
+++ b/tests/pin/CMakeLists.txt
@@ -5,6 +5,22 @@ include_directories(${PROJECT_SOURCE_DIR}/include)
 
 target_link_libraries(pin_test uicc milenage crypto storage $<$<TARGET_EXISTS:utils>:utils>)
 
+# The test enables and changes PIN1, so it runs on a private copy of the
+# filesystem instead of the one in the source tree, refreshed before each
+# run so repeated ctest invocations start from the same state.
+file(COPY ${CMAKE_SOURCE_DIR}/files DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/pristine)
+
+add_test(NAME pin_test_setup
+    COMMAND ${CMAKE_COMMAND} -E copy_directory
+        ${CMAKE_CURRENT_BINARY_DIR}/pristine/files
+        ${CMAKE_CURRENT_BINARY_DIR}/files
+)
+set_tests_properties(pin_test_setup PROPERTIES FIXTURES_SETUP pin_files)
+
 add_test(NAME pin_test COMMAND sh -c "$<TARGET_FILE:pin_test> > ${CMAKE_CURRENT_BINARY_DIR}/pin_test.out 2>&1")
-set_tests_properties(pin_test PROPERTIES WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+set_tests_properties(pin_test PROPERTIES
+    FIXTURES_REQUIRED pin_files
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+
 add_test(NAME pin_test_compare COMMAND ${CMAKE_COMMAND} -E compare_files --ignore-eol ${CMAKE_CURRENT_BINARY_DIR}/pin_test.out ${CMAKE_CURRENT_SOURCE_DIR}/pin_test.ok)
+set_tests_properties(pin_test_compare PROPERTIES DEPENDS pin_test)

--- a/tests/pin/pin_test.c
+++ b/tests/pin/pin_test.c
@@ -48,6 +48,26 @@ int main(void)
 	printf("VERIFY PIN2 remaining tries: %04x\n", sw);
 	assert((sw & 0xff00) == 0x6300);
 
+	/* CHANGE PIN must reset the retry counter on success, the same as
+	 * VERIFY PIN: a failed attempt followed by a successful change must
+	 * not leave the counter one attempt closer to blocked. PIN1 ships
+	 * disabled and CHANGE PIN refuses a disabled PIN, so enable it first. */
+	sw = transact(ctx, "002800010831323334ffffffff", NULL);
+	printf("ENABLE PIN1: %04x\n", sw);
+	assert(sw == 0x9000);
+
+	sw = transact(ctx, "002400011039393939ffffffff34333231ffffffff", NULL);
+	printf("CHANGE PIN1 with wrong old PIN: %04x\n", sw);
+	assert(sw == 0x63c2);
+
+	sw = transact(ctx, "002400011031323334ffffffff34333231ffffffff", NULL);
+	printf("CHANGE PIN1 with correct old PIN: %04x\n", sw);
+	assert(sw == 0x9000);
+
+	sw = transact(ctx, "0020000100", NULL);
+	printf("VERIFY PIN1 remaining tries after CHANGE PIN: %04x\n", sw);
+	assert(sw == 0x63c3);
+
 	ss_free_ctx(ctx);
 	return 0;
 }

--- a/tests/pin/pin_test.ok
+++ b/tests/pin/pin_test.ok
@@ -1,2 +1,6 @@
 VERIFY PIN1 remaining tries: 63c3
 VERIFY PIN2 remaining tries: 63c3
+ENABLE PIN1: 9000
+CHANGE PIN1 with wrong old PIN: 63c2
+CHANGE PIN1 with correct old PIN: 9000
+VERIFY PIN1 remaining tries after CHANGE PIN: 63c3


### PR DESCRIPTION
CHANGE PIN now resets the retry counter on success, the same as VERIFY, ENABLE, DISABLE and
UNBLOCK. Includes a regression test.
