### PR TITLE
fix: survive out-of-memory during SMS reassembly

### DIFF
--- a/include/onomondo/softsim/utils.h
+++ b/include/onomondo/softsim/utils.h
@@ -21,17 +21,30 @@ struct ss_buf {
 	size_t len;
 };
 
+/*! Allocate a new ss_buf object, tolerating allocation failure.
+ *  \param[in] len number of bytes to allocate inside ss_buf.
+ *  \returns pointer to newly allocated ss_buf object, NULL when out of memory. */
+static inline struct ss_buf *ss_buf_try_alloc(size_t len)
+{
+	struct ss_buf *sb = SS_ALLOC_N(sizeof(*sb) + len);
+
+	if (!sb)
+		return NULL;
+
+	sb->data = (uint8_t *)sb + sizeof(*sb);
+	sb->len = len;
+
+	return sb;
+}
+
 /*! Allocate a new ss_buf object.
  *  \param[in] len number of bytes to allocate inside ss_buf.
  *  \returns pointer to newly allocated ss_buf object. */
 static inline struct ss_buf *ss_buf_alloc(size_t len)
 {
-	struct ss_buf *sb = SS_ALLOC_N(sizeof(*sb) + len);
+	struct ss_buf *sb = ss_buf_try_alloc(len);
+
 	assert(sb);
-
-	sb->data = (uint8_t *)sb + sizeof(*sb);
-	sb->len = len;
-
 	return sb;
 }
 

--- a/src/softsim/uicc/uicc_sms_rx.c
+++ b/src/softsim/uicc/uicc_sms_rx.c
@@ -27,6 +27,15 @@
  * V5.9.0 Seciton 6.2 */
 #define IEI_CPI 0x70
 
+/* Concatenation cap, overridable at build time. TS 23.040 section 9.2.3.24.1
+ * allows up to 255 parts; each buffered part costs sizeof(struct
+ * ss_uicc_sms_rx_sm) of heap and the reassembled message up to 140 bytes per
+ * part, so a port on a small heap should lower this to what its remote-
+ * management traffic actually needs. */
+#ifndef SS_SMS_RX_MAX_PARTS
+#define SS_SMS_RX_MAX_PARTS 255
+#endif
+
 static void clear_state(struct ss_uicc_sms_rx_state *state)
 {
 	struct ss_uicc_sms_rx_sm *sm;
@@ -104,6 +113,16 @@ static struct ss_buf *concat_sm(struct ss_uicc_sms_rx_state *state, uint8_t *tp_
 	SS_LOGP(SSMS, LERROR, "receiving part %u/%u of message %u: %s\n", msg_part_no, msg_parts, msg_id,
 		ss_hexdump(tp_ud, tp_ud_len));
 
+	/* Refuse messages the part budget cannot hold: every buffered part
+	 * costs heap, so an over-long concatenation from the wire must not be
+	 * collected at all. */
+	if (msg_parts > SS_SMS_RX_MAX_PARTS) {
+		SS_LOGP(SSMS, LERROR, "message %u reports %u parts, refusing to buffer more than %u.\n", msg_id,
+			msg_parts, SS_SMS_RX_MAX_PARTS);
+		clear_state(state);
+		return NULL;
+	}
+
 	/* Clear state when a new message is detected */
 	if (state->msg_id != msg_id) {
 		SS_LOGP(SSMS, LERROR, "message %u is a new message, clearing state.\n", msg_id);
@@ -144,6 +163,12 @@ static struct ss_buf *concat_sm(struct ss_uicc_sms_rx_state *state, uint8_t *tp_
 
 	/* Store message in list */
 	sm = SS_ALLOC(struct ss_uicc_sms_rx_sm);
+	if (!sm) {
+		SS_LOGP(SSMS, LERROR, "no memory to buffer part %u/%u of message %u, dropping message.\n", msg_part_no,
+			msg_parts, msg_id);
+		clear_state(state);
+		return NULL;
+	}
 	memcpy(sm->tp_ud, tp_ud, tp_ud_len);
 	sm->tp_ud_len = tp_ud_len;
 	sm->msg_part_no = msg_part_no;
@@ -167,7 +192,13 @@ static struct ss_buf *concat_sm(struct ss_uicc_sms_rx_state *state, uint8_t *tp_
 	}
 
 	/* Concatenate message */
-	result = ss_buf_alloc(result_len);
+	result = ss_buf_try_alloc(result_len);
+	if (!result) {
+		SS_LOGP(SSMS, LERROR, "no memory to reassemble message %u (%zu bytes), dropping message.\n", msg_id,
+			result_len);
+		clear_state(state);
+		return NULL;
+	}
 	result_ptr = result->data;
 	for (i = 0; i < msg_parts; i++) {
 		sm = get_sm_part(state, i + 1);


### PR DESCRIPTION
Survive out-of-memory on the concatenated-SMS reassembly path, and let a port bound it.

A concatenated delivery may announce up to 255 parts (3GPP TS 23.040 §9.2.3.24.1: "This octet
shall contain a value in the range 0 to 255 indicating the total number of short messages within
the concatenated short message"); collecting one costs `sizeof(struct ss_uicc_sms_rx_sm)` of heap
per part and the final reassembly buffer up to 255 × 140 = 35 700 bytes in a single allocation. Both allocations on that path dereferenced a
failed result: the per-part `SS_ALLOC` fed `memcpy()` unchecked, and `ss_buf_alloc()` only
`assert()`s — compiled out under NDEBUG, leaving a NULL write.

- `ss_buf_try_alloc()` joins `utils.h`: identical to `ss_buf_alloc()` but returns NULL on
  allocation failure; `ss_buf_alloc()` now delegates to it and keeps its assert, so no other
  caller changes behavior.
- Both reassembly allocations check their result, log, drop the message, and clear the collection
  state — the same recovery the existing malformed-concatenation checks use.
- New `SS_SMS_RX_MAX_PARTS` (`#ifndef`-guarded, default 255 = spec maximum, so behavior is
  unchanged) rejects an over-long concatenation before any part is buffered. A port with a small
  heap can lower it to what its remote-management traffic actually needs.

Observed while here, deliberately untouched: a part count of 0 should make the receiver "ignore
the whole Information Element" (same clause), but today `msg_parts == 0` with `msg_part_no == 0`
reassembles into an empty message, and the "message id also must not be 0" comment above the
range check never checks 0. Both predate this change and deserve their own issue.

The cap branch is unreachable at the default (the announced part count is a `uint8_t`) and
`tests/` has no SMS TPDU fixtures to drive the OOM branches directly; the reassembly happy path
is covered end-to-end by the conformance testbench's OTA area. ctest 38/38 with sanitizers, and a
full testbench run records zero outcome or status-word drift against the `d0fdbff` baseline.
