### PR TITLE
perf: compile the TLV dump helpers out when logging is off

### DIFF
--- a/src/softsim/uicc/btlv_utils.c
+++ b/src/softsim/uicc/btlv_utils.c
@@ -65,6 +65,9 @@ static int decode_tag(uint16_t *tag, enum ber_tlv_cls *cls, bool *constr, uint32
 	return 0;
 }
 
+/* Logging only: compiled out so log-less builds do not keep ss_hexdump and
+ * its static buffers alive. */
+#ifdef CONFIG_USE_LOGS
 static void dump_ie(const struct ber_tlv_ie *ie, uint8_t indent, enum log_subsys subsys, enum log_level level)
 {
 	char indent_str[256];
@@ -115,6 +118,15 @@ void ss_btlv_dump(const struct ss_list *list, uint8_t indent, enum log_subsys lo
 		}
 	}
 }
+#else
+void ss_btlv_dump(const struct ss_list *list, uint8_t indent, enum log_subsys log_subsys, enum log_level log_level)
+{
+	(void)list;
+	(void)indent;
+	(void)log_subsys;
+	(void)log_level;
+}
+#endif
 
 static void free_ie(struct ber_tlv_ie *ie)
 {

--- a/src/softsim/uicc/ctlv.c
+++ b/src/softsim/uicc/ctlv.c
@@ -147,6 +147,9 @@ struct ss_list *ss_ctlv_decode(const uint8_t *enc, size_t len)
 	return list;
 }
 
+/* Logging only: compiled out so log-less builds do not keep ss_hexdump and
+ * its static buffers alive. */
+#ifdef CONFIG_USE_LOGS
 static void dump_ie(const struct cmp_tlv_ie *ie, uint8_t indent, enum log_subsys subsys, enum log_level level)
 {
 	char indent_str[256];
@@ -194,6 +197,15 @@ void ss_ctlv_dump(const struct ss_list *list, uint8_t indent, enum log_subsys lo
 		dump_ie(ie, indent, log_subsys, log_level);
 	}
 }
+#else
+void ss_ctlv_dump(const struct ss_list *list, uint8_t indent, enum log_subsys log_subsys, enum log_level log_level)
+{
+	(void)list;
+	(void)indent;
+	(void)log_subsys;
+	(void)log_level;
+}
+#endif
 
 static void free_ie(struct cmp_tlv_ie *ie)
 {

--- a/src/softsim/uicc/tlv8.c
+++ b/src/softsim/uicc/tlv8.c
@@ -109,6 +109,9 @@ struct ss_list *ss_tlv8_decode(const uint8_t *enc, size_t len)
 	return list;
 }
 
+/* Logging only: compiled out so log-less builds do not keep ss_hexdump and
+ * its static buffers alive. */
+#ifdef CONFIG_USE_LOGS
 static void dump_ie(struct tlv8_ie *ie, uint8_t indent, enum log_subsys subsys, enum log_level level)
 {
 	char indent_str[256];
@@ -150,6 +153,15 @@ void ss_tlv8_dump(const struct ss_list *list, uint8_t indent, enum log_subsys lo
 		dump_ie(ie, indent, log_subsys, log_level);
 	}
 }
+#else
+void ss_tlv8_dump(const struct ss_list *list, uint8_t indent, enum log_subsys log_subsys, enum log_level log_level)
+{
+	(void)list;
+	(void)indent;
+	(void)log_subsys;
+	(void)log_level;
+}
+#endif
 
 static void free_ie(struct tlv8_ie *ie)
 {


### PR DESCRIPTION
Building without `CONFIG_USE_LOGS` turns every `SS_LOGP` into a no-op, but the three TLV
dump helpers (`tlv8.c`, `ctlv.c`, `btlv_utils.c`) still assigned `ss_hexdump(...)` to a local
before handing it to the now-empty macro. That statement-level reference keeps `ss_hexdump` —
and its 4 KiB static ring buffer — in every log-less image, even under `--gc-sections`.

The dump helpers produce logging output and nothing else, so they now compile to empty stubs
when `CONFIG_USE_LOGS` is unset. The public `ss_btlv_dump`/`ss_ctlv_dump`/`ss_tlv8_dump`
symbols remain, so no caller changes.