### PR TITLE
perf: make the REFRESH file-list sizing overridable

### DIFF
--- a/src/softsim/uicc/fs_chg.h
+++ b/src/softsim/uicc/fs_chg.h
@@ -7,8 +7,24 @@
 #pragma once
 struct ss_list;
 
+/* Both overridable at build time. A packed path is 2 bytes per FID plus a
+ * 2-byte 0x3F00 terminator, so the deepest standard path (MF/DF/DF/EF) packs
+ * into 10 bytes; pack_path() requires an even SS_FS_CHG_PATH_MAXLEN. The
+ * list is a byte budget holding variable-length paths, sized here for
+ * SS_FS_CHG_MAX_FILES worst-case ones. It is allocated twice per SIM session
+ * (standalone and inside the REFRESH state), so a port on a small heap may
+ * want to shrink these. */
+#ifndef SS_FS_CHG_PATH_MAXLEN
 #define SS_FS_CHG_PATH_MAXLEN 20 /* bytes */
-#define SS_FS_CHG_BUF_SIZE SS_FS_CHG_PATH_MAXLEN * 100 /* bytes */
+#endif
+#ifndef SS_FS_CHG_MAX_FILES
+#define SS_FS_CHG_MAX_FILES 100
+#endif
+#define SS_FS_CHG_BUF_SIZE (SS_FS_CHG_PATH_MAXLEN * SS_FS_CHG_MAX_FILES) /* bytes */
+
+#if (SS_FS_CHG_PATH_MAXLEN % 2) || (SS_FS_CHG_PATH_MAXLEN < 10)
+#error SS_FS_CHG_PATH_MAXLEN must be even and at least 10 (MF/DF/DF/EF plus terminator)
+#endif
 
 int ss_fs_chg_add(uint8_t filelist[SS_FS_CHG_BUF_SIZE], const struct ss_list *path);
 int ss_fs_chg_len(const uint8_t filelist[SS_FS_CHG_BUF_SIZE]);


### PR DESCRIPTION
Make the REFRESH file-list sizing overridable at build time. `SS_FS_CHG_BUF_SIZE` is
`SS_FS_CHG_PATH_MAXLEN * 100` = 2000 bytes, and it exists twice per SIM session: once allocated
standalone next to the context (`softsim.c`) and once embedded in the REFRESH state inside
`ss_proactive_ctx` (`uicc_refresh.h`) — 4 KB of heap budgeted for 100 worst-case paths, on ports
where the whole heap may be a few tens of KB.

- `SS_FS_CHG_PATH_MAXLEN` gains an `#ifndef` guard; a new `SS_FS_CHG_MAX_FILES` (default 100)
  replaces the bare `100` multiplier, also guarded. Defaults are unchanged, so every existing
  build produces byte-identical buffers; a constrained port can now pass `-D` values instead of
  patching the header.
- A compile-time `#error` rejects an odd or under-sized `SS_FS_CHG_PATH_MAXLEN`: `pack_path()`
  asserts evenness at runtime, and the deepest standard path (MF/DF/DF/EF plus the 0x3F00
  terminator, ETSI TS 102 223 §8.18 encoding) packs into 10 bytes — the floor.
- The list itself is a byte budget holding variable-length packed paths, not fixed slots; the
  header comment now says so.

No functional change at defaults: ctest 38/38 with sanitizers, and a full testbench run records
zero outcome or status-word drift against the `d0fdbff` baseline.
