### PR TITLE
fix: ignore invalid SMS concatenation IEs

### DIFF
--- a/src/softsim/uicc/uicc_sms_rx.c
+++ b/src/softsim/uicc/uicc_sms_rx.c
@@ -113,6 +113,18 @@ static struct ss_buf *concat_sm(struct ss_uicc_sms_rx_state *state, uint8_t *tp_
 	SS_LOGP(SSMS, LERROR, "receiving part %u/%u of message %u: %s\n", msg_part_no, msg_parts, msg_id,
 		ss_hexdump(tp_ud, tp_ud_len));
 
+	/* TS 23.040 section 9.2.3.24.1: when the part count is zero, or the
+	 * sequence number is zero or exceeds the part count, ignore the IE and
+	 * handle the SM as a single short message. */
+	if (msg_parts == 0 || msg_part_no == 0 || msg_part_no > msg_parts) {
+		SS_LOGP(SSMS, LERROR, "ignoring invalid concatenation IE (part %u/%u), handling as single SM\n",
+			msg_part_no, msg_parts);
+		result = ss_buf_try_alloc(tp_ud_len);
+		if (result)
+			memcpy(result->data, tp_ud, tp_ud_len);
+		return result;
+	}
+
 	/* Refuse messages the part budget cannot hold: every buffered part
 	 * costs heap, so an over-long concatenation from the wire must not be
 	 * collected at all. */
@@ -137,16 +149,6 @@ static struct ss_buf *concat_sm(struct ss_uicc_sms_rx_state *state, uint8_t *tp_
 		SS_LOGP(SSMS, LERROR,
 			"message part %u of message %u reports invalid number of message parts expected %u, got %u\n",
 			msg_part_no, msg_id, state->msg_parts, msg_parts);
-		clear_state(state);
-		return NULL;
-	}
-
-	/* Make sure that the message id cannot be larger than the expected number of
-	 * messages. The message id also mut not be 0 */
-	if (msg_part_no > state->msg_parts) {
-		SS_LOGP(SSMS, LERROR,
-			"message %u reports invalid message part number %u, expecting id in range 1-%u.\n", msg_id,
-			msg_part_no, state->msg_parts);
 		clear_state(state);
 		return NULL;
 	}
@@ -341,21 +343,6 @@ int ss_uicc_sms_rx(struct ss_context *ctx, struct ss_buf *sms_tpdu, size_t *resp
 
 				/* Part of a concatencated SM received, collect partial messages */
 				concat_sm_desc_ie = ss_tlv8_get_ie_minlen(ud_hdr_dec, TS_23_040_IEI_CONCAT_SMS, 3);
-				if (concat_sm_desc_ie) {
-					uint8_t msg_parts = concat_sm_desc_ie->value->data[1];
-					uint8_t msg_part_no = concat_sm_desc_ie->value->data[2];
-
-					/* TS 23.040 section 9.2.3.24.1: when the part count
-					 * is zero, or the sequence number is zero or exceeds
-					 * the part count, the receiver shall ignore the IE
-					 * and handle the SM as a single short message. */
-					if (msg_parts == 0 || msg_part_no == 0 || msg_part_no > msg_parts) {
-						SS_LOGP(SSMS, LERROR,
-							"ignoring invalid concatenation IE (part %u/%u), handling as single SM\n",
-							msg_part_no, msg_parts);
-						concat_sm_desc_ie = NULL;
-					}
-				}
 				if (concat_sm_desc_ie) {
 					concat_sm_buf = concat_sm(state, tp_ud, tp_ud_len, concat_sm_desc_ie);
 					if (concat_sm_buf) {

--- a/src/softsim/uicc/uicc_sms_rx.c
+++ b/src/softsim/uicc/uicc_sms_rx.c
@@ -342,6 +342,21 @@ int ss_uicc_sms_rx(struct ss_context *ctx, struct ss_buf *sms_tpdu, size_t *resp
 				/* Part of a concatencated SM received, collect partial messages */
 				concat_sm_desc_ie = ss_tlv8_get_ie_minlen(ud_hdr_dec, TS_23_040_IEI_CONCAT_SMS, 3);
 				if (concat_sm_desc_ie) {
+					uint8_t msg_parts = concat_sm_desc_ie->value->data[1];
+					uint8_t msg_part_no = concat_sm_desc_ie->value->data[2];
+
+					/* TS 23.040 section 9.2.3.24.1: when the part count
+					 * is zero, or the sequence number is zero or exceeds
+					 * the part count, the receiver shall ignore the IE
+					 * and handle the SM as a single short message. */
+					if (msg_parts == 0 || msg_part_no == 0 || msg_part_no > msg_parts) {
+						SS_LOGP(SSMS, LERROR,
+							"ignoring invalid concatenation IE (part %u/%u), handling as single SM\n",
+							msg_part_no, msg_parts);
+						concat_sm_desc_ie = NULL;
+					}
+				}
+				if (concat_sm_desc_ie) {
 					concat_sm_buf = concat_sm(state, tp_ud, tp_ud_len, concat_sm_desc_ie);
 					if (concat_sm_buf) {
 						rc = handle_sm(ctx, &sm_hdr, ud_hdr, ud_hdr_len, concat_sm_buf->data,

--- a/tests/sms/CMakeLists.txt
+++ b/tests/sms/CMakeLists.txt
@@ -15,3 +15,9 @@ add_test(NAME sms_test_compare
 				 ${CMAKE_CURRENT_BINARY_DIR}/sms_test.out
 				 ${CMAKE_CURRENT_SOURCE_DIR}/sms_test.ok
 )
+
+add_executable(sms_concat_ignore_test sms_concat_ignore_test.c)
+
+target_link_libraries(sms_concat_ignore_test uicc milenage crypto storage $<$<TARGET_EXISTS:utils>:utils>)
+
+add_test(NAME sms_concat_ignore_test COMMAND sms_concat_ignore_test)

--- a/tests/sms/sms_concat_ignore_test.c
+++ b/tests/sms/sms_concat_ignore_test.c
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2026 Onomondo ApS. All rights reserved.
+ *
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+/* TS 23.040 section 9.2.3.24.1: a concatenation IE whose part count is zero,
+ * or whose sequence number is zero or exceeds the part count, shall be
+ * ignored and the SM handled as a single short message. This pins that a
+ * malformed IE neither creates reassembly state nor drops the message, and
+ * that a well-formed two-part message still reassembles. */
+
+#include <assert.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <onomondo/softsim/softsim.h>
+#include <onomondo/softsim/list.h>
+#include <onomondo/softsim/utils.h>
+#include "src/softsim/uicc/context.h"
+#include "src/softsim/uicc/uicc_sms_rx.h"
+
+/* Feed one SMS-DELIVER whose user-data header carries a concatenation IE
+ * with the given values. Returns the ss_uicc_sms_rx() result: 0 when the
+ * part was buffered, -1 when the payload reached the single/reassembled
+ * message handler (which rejects the unknown IEIa 0x00 with -1). */
+static int rx(struct ss_context *ctx, uint8_t id, uint8_t parts, uint8_t seq)
+{
+	const uint8_t tpdu[] = {
+		0x40, /* SMS-DELIVER, TP-UDHI set */
+		0x02, 0x81, 0x21, /* TP-OA: 2 digits, national */
+		0x7f, 0xf6, /* TP-PID, TP-DCS (8-bit data) */
+		0x00, 0x00, 0x00, 0x00, 0x00,  0x00, 0x00, /* TP-SCTS */
+		0x08, /* TP-UDL */
+		0x05, 0x00, 0x03, id,	parts, seq, /* UDH: concatenation IE */
+		0x41, 0x42, /* payload */
+	};
+	uint8_t response[256];
+	size_t response_len = sizeof(response);
+	struct ss_buf *sb = ss_buf_alloc_and_cpy(tpdu, sizeof(tpdu));
+	int rc;
+
+	assert(sb);
+	rc = ss_uicc_sms_rx(ctx, sb, &response_len, response);
+	ss_buf_free(sb);
+	return rc;
+}
+
+int main(void)
+{
+	struct ss_context *ctx = ss_new_ctx();
+	struct ss_uicc_sms_rx_state *state;
+
+	assert(ctx);
+	ss_reset(ctx);
+	/* ss_reset() leaves the rx state all-zero (its documented initial
+	 * form); init the part list so ss_list_empty() below is meaningful. */
+	ss_uicc_sms_rx_clear(ctx);
+	state = &ctx->proactive.sms_rx_state;
+
+	/* Malformed IEs: handled as a single SM (rc -1 from the unknown-IEIa
+	 * handler proves the payload got there), no reassembly state created. */
+	assert(rx(ctx, 7, 0, 1) == -1); /* part count 0 */
+	assert(state->msg_parts == 0 && ss_list_empty(&state->sm));
+	assert(rx(ctx, 7, 2, 0) == -1); /* sequence number 0 */
+	assert(state->msg_parts == 0 && ss_list_empty(&state->sm));
+	assert(rx(ctx, 7, 2, 3) == -1); /* sequence number > part count */
+	assert(state->msg_parts == 0 && ss_list_empty(&state->sm));
+
+	/* A well-formed two-part message still buffers and reassembles. */
+	assert(rx(ctx, 9, 2, 1) == 0); /* buffered, waiting for part 2 */
+	assert(state->msg_parts == 2 && !ss_list_empty(&state->sm));
+	assert(rx(ctx, 9, 2, 2) == -1); /* complete: reassembly delivered */
+	assert(state->msg_parts == 0 && ss_list_empty(&state->sm));
+
+	ss_free_ctx(ctx);
+	printf("ok\n");
+	return 0;
+}


### PR DESCRIPTION
A concatenation IE with a zero part count, a zero sequence number, or a sequence number above the part count is now ignored and the SM handled as a single short message, per TS 23.040 section 9.2.3.24.1. Previously such input was dropped, delivered empty, or buffered as a stray part. Covered by a new self-contained test.