### PR TITLE
fix: report 6986 (not 6981) when a DF is selected for a file-structure command

### DIFF
--- a/src/softsim/uicc/uicc_file_ops.c
+++ b/src/softsim/uicc/uicc_file_ops.c
@@ -207,6 +207,13 @@ static int verify_file_struct(struct ss_apdu *apdu, struct ss_file *file, bool r
 		return SS_SW_ERR_CMD_NOT_ALLOWED_NO_EF_SELECTED;
 	}
 
+	/* A DF or ADF is not an EF at all, which is a different condition than
+	 * an EF whose structure does not fit the command. */
+	if (file->fcp_file_descr->type == SS_FCP_DF_OR_ADF) {
+		apdu->le = 0;
+		return SS_SW_ERR_CMD_NOT_ALLOWED_NO_EF_SELECTED;
+	}
+
 	if (file->fcp_file_descr->type != SS_FCP_WORKING_EF) {
 		apdu->le = 0;
 		return SS_SW_ERR_CMD_NOT_ALLOWED_INCOMP_FILE_STRUCT;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -21,6 +21,7 @@ add_subdirectory(tlv8)
 add_subdirectory(utils)
 add_subdirectory(pin)
 add_subdirectory(read_binary)
+add_subdirectory(read_on_df)
 add_subdirectory(suspend)
 add_subdirectory(init)
 

--- a/tests/read_on_df/CMakeLists.txt
+++ b/tests/read_on_df/CMakeLists.txt
@@ -1,0 +1,14 @@
+# Copyright (c) 2026 Onomondo ApS. All rights reserved.
+# SPDX-License-Identifier: GPL-3.0-only
+
+add_executable(read_on_df_test read_on_df_test.c)
+
+include_directories(${PROJECT_SOURCE_DIR})
+include_directories(${PROJECT_SOURCE_DIR}/include)
+
+target_link_libraries(read_on_df_test uicc milenage crypto storage $<$<TARGET_EXISTS:utils>:utils>)
+
+add_test(NAME read_on_df_test COMMAND sh -c "$<TARGET_FILE:read_on_df_test> > ${CMAKE_CURRENT_BINARY_DIR}/read_on_df_test.out 2>&1")
+set_tests_properties(read_on_df_test PROPERTIES WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+add_test(NAME read_on_df_test_compare COMMAND ${CMAKE_COMMAND} -E compare_files --ignore-eol ${CMAKE_CURRENT_BINARY_DIR}/read_on_df_test.out ${CMAKE_CURRENT_SOURCE_DIR}/read_on_df_test.ok)
+set_tests_properties(read_on_df_test_compare PROPERTIES DEPENDS read_on_df_test)

--- a/tests/read_on_df/read_on_df_test.c
+++ b/tests/read_on_df/read_on_df_test.c
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2026 Onomondo ApS. All rights reserved.
+ *
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+#include <onomondo/softsim/softsim.h>
+#include <onomondo/softsim/utils.h>
+
+/* allow test to silence noisy logs when comparing output */
+extern uint32_t ss_log_mask;
+
+/* A file command with a DF or ADF selected must answer 6986, command not
+ * allowed, no EF selected -- not 6981, which is for an EF whose structure
+ * does not fit the command. Read-only: nothing here writes to files/. */
+#define SELECT_MF "00a4000c023f00"
+#define SELECT_ADF "00a4000c027ff0"
+#define SELECT_ICCID "00a4000c022fe2"
+
+static uint16_t transact(struct ss_context *ctx, const char *hex)
+{
+	uint8_t cmd[300];
+	uint8_t resp[400];
+	size_t cmd_len = ss_binary_from_hexstr(cmd, sizeof(cmd), hex);
+	size_t resp_len = ss_application_apdu_transact(ctx, resp, sizeof(resp), cmd, &cmd_len);
+	if (resp_len >= 2)
+		return (uint16_t)((resp[resp_len - 2] << 8) | resp[resp_len - 1]);
+	return 0;
+}
+
+int main(void)
+{
+	struct ss_context *ctx;
+	uint16_t sw;
+
+	ss_log_mask = 0;
+	ctx = ss_new_ctx();
+	ss_reset(ctx);
+	ss_log_mask = 0;
+
+	/* The MF is current after a reset. */
+	sw = transact(ctx, "00b0000001");
+	printf("READ BINARY with the MF selected: %04x\n", sw);
+	assert(sw == 0x6986);
+
+	sw = transact(ctx, "00b2010401");
+	printf("READ RECORD with the MF selected: %04x\n", sw);
+	assert(sw == 0x6986);
+
+	sw = transact(ctx, SELECT_ADF);
+	printf("SELECT ADF.USIM: %04x\n", sw);
+	assert(sw == 0x9000);
+
+	sw = transact(ctx, "00b0000001");
+	printf("READ BINARY with the ADF selected: %04x\n", sw);
+	assert(sw == 0x6986);
+
+	/* An EF whose structure does not fit the command keeps 6981. */
+	sw = transact(ctx, SELECT_MF);
+	printf("SELECT MF: %04x\n", sw);
+	assert(sw == 0x9000);
+
+	sw = transact(ctx, SELECT_ICCID);
+	printf("SELECT EF.ICCID: %04x\n", sw);
+	assert(sw == 0x9000);
+
+	sw = transact(ctx, "00b2010401");
+	printf("READ RECORD on a transparent EF: %04x\n", sw);
+	assert(sw == 0x6981);
+
+	sw = transact(ctx, "00b000000a");
+	printf("READ BINARY with an EF selected: %04x\n", sw);
+	assert(sw == 0x9000);
+
+	ss_free_ctx(ctx);
+	return 0;
+}

--- a/tests/read_on_df/read_on_df_test.ok
+++ b/tests/read_on_df/read_on_df_test.ok
@@ -1,0 +1,8 @@
+READ BINARY with the MF selected: 6986
+READ RECORD with the MF selected: 6986
+SELECT ADF.USIM: 9000
+READ BINARY with the ADF selected: 6986
+SELECT MF: 9000
+SELECT EF.ICCID: 9000
+READ RECORD on a transparent EF: 6981
+READ BINARY with an EF selected: 9000


### PR DESCRIPTION
`verify_file_struct` answered 6981 ("command incompatible with file structure") for anything
that is not a working EF. A DF/ADF has no structure to be incompatible with — TS 102 221 lists
6986 ("no EF selected") for a file command issued with a directory selected. The check now
separates the two; `tests/read_on_df` covers both, read-only against the tracked `files/`.

Side effect, intended: SFI-referenced READ/UPDATE RECORD that fails to resolve also lands in
this check, so those paths move from 6981 to 6986 too (the underlying SFI resolution is a
separate, still-open defect).

Checked against physical UICCs: 6986 for MF/ADF-current file commands, 6981 unchanged for a
genuine structure mismatch — the two SWs stay distinct.
