### PR TITLE
ci: drop release-type so the release-please config is read

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -2,9 +2,7 @@
   "packages": {
     ".": {
       "release-type": "simple",
-      "extra-files": [
-        { "type": "generic", "path": "CMakeLists.txt" }
-      ]
+      "extra-files": ["CMakeLists.txt"]
     }
   }
 }

--- a/.github/workflows/release_please.yml
+++ b/.github/workflows/release_please.yml
@@ -18,7 +18,6 @@ jobs:
       - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         id: release
         with:
-          release-type: simple
           target-branch: master
           config-file: .github/release-please-config.json
           manifest-file: .github/.release-please-manifest.json


### PR DESCRIPTION
#169 added `config-file:` but left `release-type: simple` in place, and the action takes `Manifest.fromConfig` whenever `release-type` is set — a path that never reads `config-file` or `manifest-file`. That made both #169 and the pre-existing `manifest-file:` input inert.
