### PR TITLE
fix: demand only the encoded octets in the SMS address length check

### DIFF
--- a/src/softsim/uicc/sms.c
+++ b/src/softsim/uicc/sms.c
@@ -115,7 +115,7 @@ static int encode_addr(uint8_t *addr, size_t addr_len, const struct ss_sms_addr 
 	addr[bytes_used] |= addr_dec->numbering_plan & 0x0F;
 	bytes_used++;
 
-	if (addr_len < bytes_used + n_digits + 1 / 2)
+	if (addr_len < bytes_used + (n_digits + 1) / 2)
 		return -ENOMEM;
 
 	/* Encode digits */

--- a/tests/sms/sms_test.c
+++ b/tests/sms/sms_test.c
@@ -333,6 +333,26 @@ void ss_sms_addr_length_overflow_test(void)
 	printf("\n");
 }
 
+/* Regression test: an exact-fit buffer must be enough for the address
+ * encoder (its length check used to demand one byte per digit). */
+void ss_sms_addr_encode_exact_fit_test(void)
+{
+	uint8_t result[18]; /* 5 hdr + 12 addr (20 digits) + 1 TP-CDL */
+	struct ss_sm_hdr sm_hdr;
+	int rc;
+
+	printf("regression: encode SMS-COMMAND with 20-digit TP-DA into exact-fit buffer\n");
+
+	memset(&sm_hdr, 0, sizeof(sm_hdr));
+	sm_hdr.tp_mti = SMS_MTI_COMMAND;
+	strcpy(sm_hdr.u.sms_command.tp_da.digits, "12345678901234567890");
+
+	rc = ss_sms_hdr_encode(result, sizeof(result), &sm_hdr);
+	printf(" rc=%i (expected 18)\n", rc);
+	assert(rc == 18);
+	printf("\n");
+}
+
 int main(int argc, char **argv)
 {
 	ss_sms_hdr_decode_sms_deliver_test();
@@ -345,5 +365,6 @@ int main(int argc, char **argv)
 	ss_uicc_sms_tx_test_single();
 	ss_uicc_sms_tx_test_multi();
 	ss_sms_addr_length_overflow_test();
+	ss_sms_addr_encode_exact_fit_test();
 	return 0;
 }

--- a/tests/sms/sms_test.ok
+++ b/tests/sms/sms_test.ok
@@ -63,3 +63,6 @@ test ss_uicc_sms_tx (message that needs to be splitted over multiple SM)
 regression: reject SMS-DELIVER with oversized Address-Length
  rc=-22 (expected < 0)
 
+regression: encode SMS-COMMAND with 20-digit TP-DA into exact-fit buffer
+ rc=18 (expected 18)
+


### PR DESCRIPTION
In `encode_addr()` (sms.c) the length check `addr_len < bytes_used + n_digits + 1 / 2` divides only the literal 1, so it demanded one buffer byte per digit instead of the `⌈n_digits/2⌉` BCD octets actually written — spuriously rejecting exact-fit buffers with `-ENOMEM` (surfaced as `-EINVAL`). Over-strict only, never an overflow, and unreachable from the runtime TX path (`ss_uicc_sms_tx()` always passes a 164-byte buffer).
Fix: parenthesize to `(n_digits + 1) / 2`. Includes an exact-fit SMS-COMMAND regression test (20-digit TP-DA into an 18-byte buffer); reverting the fix makes it fail.
