### PR TITLE
fix: close before delete on failed storage write

### DIFF
--- a/src/softsim/storage.c
+++ b/src/softsim/storage.c
@@ -332,8 +332,8 @@ int ss_storage_update_def(const struct ss_list *path)
 		fwrite_rc = ss_fwrite(hex, sizeof(hex) - 1, 1, fd);
 		if (fwrite_rc != 1) {
 			SS_LOGP(SSTORAGE, LERROR, "unable to write file definition: %s\n", host_path);
-			ss_storage_delete(path);
 			ss_fclose(fd);
+			ss_storage_delete(path);
 			return -EINVAL;
 		}
 	}
@@ -371,8 +371,8 @@ int ss_storage_create_file(const struct ss_list *path, size_t file_len)
 	for (i = 0; i < file_len * 2; i++) {
 		if (ss_fwrite("f", sizeof(char), 1, fd) != 1) {
 			SS_LOGP(SSTORAGE, LERROR, "unable to prefill content file: %s\n", host_path);
-			ss_storage_delete(path);
 			ss_fclose(fd);
+			ss_storage_delete(path);
 			return -EINVAL;
 		}
 	}

--- a/src/softsim/storage_compact.c
+++ b/src/softsim/storage_compact.c
@@ -336,8 +336,8 @@ int ss_storage_update_def(const struct ss_list *path)
 
 	if (fwrite_rc != 1) {
 		SS_LOGP(SSTORAGE, LERROR, "unable to write file definition: %s\n", host_path);
-		ss_storage_delete(path);
 		ss_fclose(fd);
+		ss_storage_delete(path);
 		return -EINVAL;
 	}
 	ss_fclose(fd);
@@ -374,8 +374,8 @@ int ss_storage_create_file(const struct ss_list *path, size_t file_len)
 	for (i = 0; i < file_len; i++) {
 		if (ss_fwrite(&f, 1, 1, fd) != 1) {
 			SS_LOGP(SSTORAGE, LERROR, "unable to prefill content file: %s\n", host_path);
-			ss_storage_delete(path);
 			ss_fclose(fd);
+			ss_storage_delete(path);
 			return -EINVAL;
 		}
 	}

--- a/tests/storage/storage_test.c
+++ b/tests/storage/storage_test.c
@@ -9,10 +9,40 @@
 #include <stdio.h>
 #include <string.h>
 #include <assert.h>
+#include <sys/stat.h>
+#include <onomondo/softsim/fs.h>
 #include <onomondo/softsim/storage.h>
 #include <onomondo/softsim/list.h>
 #include "src/softsim/uicc/fs.h"
 #include "src/softsim/uicc/fs_utils.h"
+
+/* fs.c declares the storage entry points weak, so these stand in for three of
+ * them: one cuts the first write of the chosen size short, the other two record
+ * the order the core closes and deletes in. */
+static size_t fail_write_size;
+static int seq, close_seq, delete_seq;
+
+size_t ss_fwrite(const void *ptr, size_t size, size_t count, ss_FILE f)
+{
+	if (size == fail_write_size) {
+		fail_write_size = 0;
+		return 0;
+	}
+	return fwrite(ptr, size, count, (FILE *)f);
+}
+
+int ss_fclose(ss_FILE f)
+{
+	close_seq = ++seq;
+	return fclose((FILE *)f);
+}
+
+int ss_delete_file(const char *path)
+{
+	delete_seq = ++seq;
+	remove(path);
+	return 0; /* the content file may not exist yet; never fall through to ss_delete_dir */
+}
 
 void test_storage_path_default(void)
 {
@@ -123,6 +153,32 @@ void test_create_record_file_reports_failure(void)
 	printf("Create record file failure propagation test passed\n");
 }
 
+/* A failed write must close the handle before the file is deleted: on a port
+ * whose handle is the file's cache node, delete frees what close then uses. */
+void test_failed_write_closes_before_delete(void)
+{
+	struct ss_list path;
+	size_t sizes[] = { 2, 1 }; /* 2: definition hex pair, 1: content prefill byte */
+	size_t i;
+	int rc;
+
+	mkdir("close_order_files", 0700);
+	rc = ss_storage_set_path("./close_order_files");
+	assert(rc == 0);
+
+	for (i = 0; i < 2; i++) {
+		seq = close_seq = delete_seq = 0;
+		fail_write_size = sizes[i];
+		ss_list_init(&path);
+		rc = ss_fs_utils_create_record_file(&path, 0x5F100001, 2, 0x1f);
+		ss_path_reset(&path);
+		assert(rc < 0);
+		assert(close_seq > 0 && delete_seq > 0);
+		assert(close_seq < delete_seq);
+	}
+	printf("Failed write closes before delete test passed\n");
+}
+
 int main(void)
 {
 	test_storage_path_default();
@@ -134,5 +190,6 @@ int main(void)
 	test_storage_path_special_chars();
 	test_storage_path_empty_string();
 	test_create_record_file_reports_failure();
+	test_failed_write_closes_before_delete();
 	return 0;
 }

--- a/tests/storage/storage_test.ok
+++ b/tests/storage/storage_test.ok
@@ -8,3 +8,4 @@ Multiple path changes test passed
 Special characters in path test passed
 Empty path rejection test passed
 Create record file failure propagation test passed
+Failed write closes before delete test passed


### PR DESCRIPTION
On a failed definition or content write the storage layer deleted the file while the write handle was still open.
Close the handle first, then delete.
